### PR TITLE
Add full trading pipeline: downloader, indicators, LSTM model manager, risk, live loop, Futu connector, and backtest engine

### DIFF
--- a/v3_pipeline/backtest/engine.py
+++ b/v3_pipeline/backtest/engine.py
@@ -1,0 +1,139 @@
+import logging
+import sys
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import pandas as pd
+
+from v3_pipeline.models.manager import ModelManager
+
+
+def _build_stderr_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler(sys.stderr)
+    formatter = logging.Formatter(
+        "%(asctime)s | %(name)s | %(levelname)s | %(message)s",
+        "%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.propagate = False
+    return logger
+
+
+@dataclass
+class BacktestConfig:
+    buy_threshold: float = 0.01
+    sell_threshold: float = 0.01
+    initial_cash: float = 100000.0
+    commission: float = 0.001
+
+
+class KiroStrategyFactory:
+    """Factory to inject ModelManager and feature data into Backtrader strategy."""
+
+    @staticmethod
+    def build(model_manager: ModelManager, featured_df: pd.DataFrame, config: BacktestConfig):
+        import backtrader as bt
+
+        class KiroStrategy(bt.Strategy):
+            params = dict(
+                threshold_buy=config.buy_threshold,
+                threshold_sell=config.sell_threshold,
+            )
+
+            def __init__(self):
+                self.model_manager = model_manager
+                self.featured_df = featured_df.reset_index(drop=True)
+                self.logger = _build_stderr_logger("KiroStrategy")
+
+            def next(self):
+                idx = len(self) - 1
+                if idx < 0 or idx >= len(self.featured_df):
+                    return
+
+                current_price = float(self.data.close[0])
+                window_df = self.featured_df.iloc[: idx + 1]
+
+                try:
+                    predicted_price = self.model_manager.predict(window_df)
+                except Exception as exc:
+                    self.logger.warning("Prediction skipped at idx=%d: %s", idx, exc)
+                    return
+
+                buy_trigger = current_price * (1 + self.params.threshold_buy)
+                sell_trigger = current_price * (1 - self.params.threshold_sell)
+
+                if not self.position and predicted_price > buy_trigger:
+                    self.buy()
+                    self.logger.info(
+                        "BUY idx=%d current=%.4f predicted=%.4f",
+                        idx,
+                        current_price,
+                        predicted_price,
+                    )
+                elif self.position and predicted_price < sell_trigger:
+                    self.sell()
+                    self.logger.info(
+                        "SELL idx=%d current=%.4f predicted=%.4f",
+                        idx,
+                        current_price,
+                        predicted_price,
+                    )
+
+        return KiroStrategy
+
+
+class BacktestEngine:
+    def __init__(self, config: Optional[BacktestConfig] = None) -> None:
+        self.config = config or BacktestConfig()
+        self.logger = _build_stderr_logger(self.__class__.__name__)
+
+    def run(self, featured_df: pd.DataFrame, model_manager: ModelManager) -> Dict[str, float]:
+        import backtrader as bt
+
+        df = featured_df.copy()
+        if "Date" not in df.columns:
+            raise ValueError("featured_df must contain 'Date'")
+
+        bt_df = df[["Date", "Open", "High", "Low", "Close", "Volume"]].copy()
+        bt_df["Date"] = pd.to_datetime(bt_df["Date"], errors="coerce")
+        bt_df = bt_df.dropna(subset=["Date"]).set_index("Date")
+
+        cerebro = bt.Cerebro()
+        cerebro.broker.setcash(self.config.initial_cash)
+        cerebro.broker.setcommission(commission=self.config.commission)
+
+        data_feed = bt.feeds.PandasData(dataname=bt_df)
+        cerebro.adddata(data_feed)
+
+        strategy_cls = KiroStrategyFactory.build(model_manager, df.reset_index(drop=True), self.config)
+        cerebro.addstrategy(strategy_cls)
+
+        cerebro.addanalyzer(bt.analyzers.Returns, _name="returns")
+        cerebro.addanalyzer(bt.analyzers.SharpeRatio, _name="sharpe")
+        cerebro.addanalyzer(bt.analyzers.DrawDown, _name="drawdown")
+
+        self.logger.info("Starting backtest with initial cash %.2f", self.config.initial_cash)
+        results = cerebro.run()
+        strat = results[0]
+
+        returns_analysis = strat.analyzers.returns.get_analysis()
+        sharpe_analysis = strat.analyzers.sharpe.get_analysis()
+        drawdown_analysis = strat.analyzers.drawdown.get_analysis()
+
+        total_return = float(returns_analysis.get("rtot", 0.0))
+        sharpe_ratio = float(sharpe_analysis.get("sharperatio", 0.0) or 0.0)
+        max_drawdown = float(drawdown_analysis.get("max", {}).get("drawdown", 0.0))
+
+        summary = {
+            "total_return": total_return,
+            "sharpe_ratio": sharpe_ratio,
+            "max_drawdown": max_drawdown,
+            "final_value": float(cerebro.broker.getvalue()),
+        }
+        self.logger.info("Backtest summary: %s", summary)
+        return summary

--- a/v3_pipeline/core/futu_connector.py
+++ b/v3_pipeline/core/futu_connector.py
@@ -1,0 +1,132 @@
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from typing import Optional
+
+import pandas as pd
+
+
+def _build_stderr_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler(sys.stderr)
+    formatter = logging.Formatter(
+        "%(asctime)s | %(name)s | %(levelname)s | %(message)s",
+        "%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.propagate = False
+    return logger
+
+
+@dataclass
+class FutuConfig:
+    host: str = os.getenv("FUTU_OPEND_HOST", "127.0.0.1")
+    port: int = 11111
+    market_prefix: str = "US"
+    trd_env: str = "SIMULATE"
+
+
+class FutuConnector:
+    """Minimal Futu OpenAPI adapter for quote polling, state sync, and order placement."""
+
+    def __init__(self, config: Optional[FutuConfig] = None) -> None:
+        self.config = config or FutuConfig()
+        self.logger = _build_stderr_logger(self.__class__.__name__)
+        self.quote_ctx = None
+        self.trade_ctx = None
+        self.ft = None
+
+    def connect(self) -> None:
+        import futu as ft
+
+        self.ft = ft
+        self.quote_ctx = ft.OpenQuoteContext(host=self.config.host, port=self.config.port)
+        self.trade_ctx = ft.OpenUSTradeContext(host=self.config.host, port=self.config.port)
+        self.logger.info("Connected to Futu OpenD at %s:%s (trd_env=%s)", self.config.host, self.config.port, self.config.trd_env)
+
+    def close(self) -> None:
+        if self.quote_ctx is not None:
+            self.quote_ctx.close()
+        if self.trade_ctx is not None:
+            self.trade_ctx.close()
+        self.logger.info("Closed Futu contexts")
+
+    def _resolved_trd_env(self):
+        if self.ft is None:
+            raise RuntimeError("Futu SDK not loaded. Call connect() first.")
+        return getattr(self.ft.TrdEnv, self.config.trd_env, self.ft.TrdEnv.SIMULATE)
+
+    def get_latest_quote(self, symbol: str) -> dict:
+        if self.quote_ctx is None or self.ft is None:
+            raise RuntimeError("FutuConnector not connected")
+
+        code = f"{self.config.market_prefix}.{symbol}"
+        ret, df = self.quote_ctx.get_stock_quote([code])
+        if ret != self.ft.RET_OK or df.empty:
+            raise RuntimeError(f"Failed to fetch quote for {code}: {df}")
+
+        row = df.iloc[0]
+        return {
+            "Date": pd.Timestamp.now(),
+            "Open": float(row.get("open_price", row.get("last_price", 0.0))),
+            "High": float(row.get("high_price", row.get("last_price", 0.0))),
+            "Low": float(row.get("low_price", row.get("last_price", 0.0))),
+            "Close": float(row.get("last_price", 0.0)),
+            "Volume": float(row.get("volume", 0.0)),
+        }
+
+    def get_sync_assets(self) -> dict:
+        if self.trade_ctx is None or self.ft is None:
+            raise RuntimeError("FutuConnector not connected")
+
+        ret, data = self.trade_ctx.accinfo_query(trd_env=self._resolved_trd_env())
+        if ret != self.ft.RET_OK or data is None or data.empty:
+            raise RuntimeError(f"Failed to sync assets: {data}")
+
+        row = data.iloc[0]
+        assets = {
+            "total_assets": float(row.get("total_assets", 0.0)),
+            "cash": float(row.get("cash", 0.0)),
+            "power": float(row.get("power", 0.0)),
+        }
+        return assets
+
+    def get_sync_positions(self) -> pd.DataFrame:
+        if self.trade_ctx is None or self.ft is None:
+            raise RuntimeError("FutuConnector not connected")
+
+        ret, data = self.trade_ctx.position_list_query(trd_env=self._resolved_trd_env())
+        if ret != self.ft.RET_OK:
+            raise RuntimeError(f"Failed to sync positions: {data}")
+
+        if data is None:
+            return pd.DataFrame()
+        return data.copy()
+
+    def place_order(self, symbol: str, qty: int, side: str, price: Optional[float] = None) -> object:
+        if self.trade_ctx is None or self.ft is None:
+            raise RuntimeError("FutuConnector not connected")
+        if qty <= 0:
+            raise ValueError("qty must be > 0")
+
+        code = f"{self.config.market_prefix}.{symbol}"
+        trd_side = self.ft.TrdSide.BUY if side.upper() == "BUY" else self.ft.TrdSide.SELL
+        order_type = self.ft.OrderType.NORMAL
+        order_price = 0 if price is None else float(price)
+        ret, data = self.trade_ctx.place_order(
+            price=order_price,
+            qty=qty,
+            code=code,
+            trd_side=trd_side,
+            order_type=order_type,
+            trd_env=self._resolved_trd_env(),
+        )
+        if ret != self.ft.RET_OK:
+            raise RuntimeError(f"Order placement failed: {data}")
+        self.logger.info("Order placed: %s %d %s", side.upper(), qty, symbol)
+        return data

--- a/v3_pipeline/core/main_loop.py
+++ b/v3_pipeline/core/main_loop.py
@@ -1,0 +1,191 @@
+import logging
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+import pandas as pd
+
+from notifier import send_tg_msg
+from v3_pipeline.core.futu_connector import FutuConnector
+from v3_pipeline.features.indicators import TechnicalIndicatorGenerator
+from v3_pipeline.models.manager import ModelManager
+from v3_pipeline.risk.manager import RiskController
+
+
+def _build_stderr_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler(sys.stderr)
+    formatter = logging.Formatter(
+        "%(asctime)s | %(name)s | %(levelname)s | %(message)s",
+        "%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.propagate = False
+    return logger
+
+
+@dataclass
+class LiveConfig:
+    symbol: str = "TSLA"
+    polling_seconds: int = 60
+    prediction_threshold: float = 0.01
+    auto_trade: bool = False
+    paper_trading: bool = True
+
+
+class LiveTradingLoop:
+    """24/7-style live loop bridging real-time data -> features -> model -> execution."""
+
+    def __init__(
+        self,
+        model_manager: ModelManager,
+        risk_controller: RiskController,
+        futu_connector: Optional[FutuConnector] = None,
+        feature_generator: Optional[TechnicalIndicatorGenerator] = None,
+        config: Optional[LiveConfig] = None,
+    ) -> None:
+        self.model_manager = model_manager
+        self.risk_controller = risk_controller
+        self.futu_connector = futu_connector or FutuConnector()
+        self.feature_generator = feature_generator or TechnicalIndicatorGenerator()
+        self.config = config or LiveConfig()
+        self.logger = _build_stderr_logger(self.__class__.__name__)
+
+        self.market_buffer = pd.DataFrame(columns=["Date", "Open", "High", "Low", "Close", "Volume"])
+        self.equity_peak = 0.0
+        self.account_value = 100000.0
+        self.position_qty = 0
+        self.highest_price_since_entry = 0.0
+
+    def start(self) -> None:
+        self.logger.info(
+            "Starting live loop symbol=%s auto_trade=%s paper_trading=%s",
+            self.config.symbol,
+            self.config.auto_trade,
+            self.config.paper_trading,
+        )
+        self.futu_connector.connect()
+        try:
+            while True:
+                self.run_one_cycle()
+                time.sleep(self.config.polling_seconds)
+        finally:
+            self.futu_connector.close()
+
+    def run_one_cycle(self) -> None:
+        self._sync_broker_state()
+
+        quote = self.futu_connector.get_latest_quote(self.config.symbol)
+        self.market_buffer = pd.concat([self.market_buffer, pd.DataFrame([quote])], ignore_index=True)
+        self.market_buffer["Date"] = pd.to_datetime(self.market_buffer["Date"], errors="coerce")
+        self.market_buffer = (
+            self.market_buffer.dropna(subset=["Date"])
+            .sort_values("Date")
+            .drop_duplicates(subset=["Date"], keep="last")
+            .reset_index(drop=True)
+        )
+
+        featured = self.feature_generator.generate(self.market_buffer).dropna().reset_index(drop=True)
+        if len(featured) <= self.model_manager.data_preparer.lookback:
+            self.logger.info("Warmup: waiting for more bars (%d/%d)", len(featured), self.model_manager.data_preparer.lookback)
+            return
+
+        current_price = float(featured.iloc[-1]["Close"])
+        prediction = self.model_manager.predict(featured)
+
+        # Use broker-synced values as baseline for risk/signals.
+        self.equity_peak = max(self.equity_peak, self.account_value)
+
+        if self.risk_controller.circuit_breaker_triggered(self.equity_peak, self.account_value):
+            self._notify(f"🚨 Circuit breaker hit. Equity={self.account_value:.2f}")
+            return
+
+        action = "HOLD"
+        threshold_up = current_price * (1 + self.config.prediction_threshold)
+        threshold_down = current_price * (1 - self.config.prediction_threshold)
+
+        if self.position_qty > 0:
+            self.highest_price_since_entry = max(self.highest_price_since_entry, current_price)
+            if self.risk_controller.should_stop_out(current_price, self.highest_price_since_entry):
+                self._execute("SELL", self.position_qty, current_price, reason="trailing_stop")
+                action = "SELL"
+
+        if action == "HOLD":
+            if prediction > threshold_up and self.position_qty == 0:
+                qty = self.risk_controller.calculate_position_size(self.account_value, current_price)
+                if qty > 0:
+                    self._execute("BUY", qty, current_price, reason="model_signal")
+                    action = "BUY"
+            elif prediction < threshold_down and self.position_qty > 0:
+                self._execute("SELL", self.position_qty, current_price, reason="model_signal")
+                action = "SELL"
+
+        self._notify(
+            f"💓 {datetime.utcnow().isoformat()} {self.config.symbol} "
+            f"price={current_price:.4f} pred={prediction:.4f} action={action} "
+            f"equity={self.account_value:.2f} position={self.position_qty}"
+        )
+
+    def _sync_broker_state(self) -> None:
+        """Sync account value and symbol position from Futu; keep last known state on failure."""
+        try:
+            assets = self.futu_connector.get_sync_assets()
+            synced_value = float(assets.get("total_assets", self.account_value))
+            if synced_value > 0:
+                self.account_value = synced_value
+                self.logger.info("Synced account value: %.2f", self.account_value)
+        except Exception as exc:
+            self.logger.warning("Asset sync failed, using last known account value %.2f: %s", self.account_value, exc)
+
+        try:
+            positions = self.futu_connector.get_sync_positions()
+            synced_qty = 0
+            if not positions.empty:
+                symbol_code = f"{self.futu_connector.config.market_prefix}.{self.config.symbol}"
+                if "code" in positions.columns:
+                    row = positions[positions["code"] == symbol_code]
+                elif "stock_name" in positions.columns:
+                    row = positions[positions["stock_name"] == self.config.symbol]
+                else:
+                    row = pd.DataFrame()
+
+                if not row.empty:
+                    qty_col = "qty" if "qty" in row.columns else "can_sell_qty" if "can_sell_qty" in row.columns else None
+                    if qty_col is not None:
+                        synced_qty = int(float(row.iloc[0][qty_col]))
+
+            self.position_qty = max(0, synced_qty)
+            if self.position_qty == 0:
+                self.highest_price_since_entry = 0.0
+            self.logger.info("Synced position qty for %s: %d", self.config.symbol, self.position_qty)
+        except Exception as exc:
+            self.logger.warning("Position sync failed, using last known position %d: %s", self.position_qty, exc)
+
+    def _execute(self, side: str, qty: int, price: float, reason: str) -> None:
+        self.logger.info("Execute %s qty=%d price=%.4f reason=%s", side, qty, price, reason)
+
+        if side == "BUY":
+            self.position_qty += qty
+            self.highest_price_since_entry = price
+        elif side == "SELL":
+            self.position_qty = max(0, self.position_qty - qty)
+            if self.position_qty == 0:
+                self.highest_price_since_entry = 0.0
+
+        if self.config.auto_trade and not self.config.paper_trading:
+            self.futu_connector.place_order(self.config.symbol, qty, side, price)
+        else:
+            self.logger.info("Paper trading mode: simulated %s %d %s", side, qty, self.config.symbol)
+
+    def _notify(self, message: str) -> None:
+        self.logger.info(message)
+        try:
+            send_tg_msg(message)
+        except Exception as exc:
+            self.logger.warning("Telegram heartbeat failed: %s", exc)

--- a/v3_pipeline/data/downloader.py
+++ b/v3_pipeline/data/downloader.py
@@ -1,0 +1,163 @@
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+REQUIRED_COLUMNS = ["Date", "Open", "High", "Low", "Close", "Volume"]
+
+
+def _build_stderr_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler(sys.stderr)
+    formatter = logging.Formatter(
+        "%(asctime)s | %(name)s | %(levelname)s | %(message)s",
+        "%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.propagate = False
+    return logger
+
+
+@dataclass
+class DownloadConfig:
+    storage_dir: Path = Path("v3_pipeline/data/storage")
+    auto_save: bool = True
+    default_format: str = "parquet"
+
+
+class HistoricalDataDownloader:
+    """Acquisition module for historical OHLCV data.
+
+    Provides robust yfinance download with schema normalization:
+    ['Date', 'Open', 'High', 'Low', 'Close', 'Volume'].
+    """
+
+    def __init__(self, config: Optional[DownloadConfig] = None):
+        self.config = config or DownloadConfig()
+        self.storage_dir = Path(self.config.storage_dir)
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self.logger = _build_stderr_logger(self.__class__.__name__)
+
+    def fetch_history(
+        self,
+        symbol: str,
+        start_date: str,
+        end_date: str,
+        interval: str = "1d",
+        save: Optional[bool] = None,
+        file_format: Optional[str] = None,
+    ) -> pd.DataFrame:
+        self.logger.info(
+            "Downloading %s from yfinance (%s -> %s, interval=%s)",
+            symbol,
+            start_date,
+            end_date,
+            interval,
+        )
+        try:
+            import yfinance as yf
+
+            raw = yf.download(
+                symbol,
+                start=start_date,
+                end=end_date,
+                interval=interval,
+                progress=False,
+                auto_adjust=False,
+            )
+        except Exception as exc:
+            self.logger.exception("yfinance download failed for %s: %s", symbol, exc)
+            raise
+
+        if raw.empty:
+            message = (
+                f"No data returned for symbol={symbol}, interval={interval}, "
+                f"range={start_date}..{end_date}"
+            )
+            self.logger.error(message)
+            raise ValueError(message)
+
+        normalized = self._normalize_schema(raw)
+        self.logger.info("Downloaded %d rows for %s", len(normalized), symbol)
+
+        should_save = self.config.auto_save if save is None else save
+        if should_save:
+            fmt = file_format or self.config.default_format
+            self.save_history(normalized, symbol=symbol, file_format=fmt)
+
+        return normalized
+
+    def save_history(self, data: pd.DataFrame, symbol: str, file_format: str = "parquet") -> Path:
+        safe_symbol = symbol.replace("/", "_").replace(" ", "_")
+        file_format = file_format.lower().strip()
+
+        if file_format not in {"parquet", "csv"}:
+            raise ValueError("file_format must be one of {'parquet', 'csv'}")
+
+        filename = f"{safe_symbol}_history.{file_format}"
+        output_path = self.storage_dir / filename
+
+        try:
+            if file_format == "parquet":
+                data.to_parquet(output_path, index=False)
+            else:
+                data.to_csv(output_path, index=False)
+            self.logger.info("Saved %s rows to %s", len(data), output_path)
+        except Exception as exc:
+            self.logger.exception("Failed to save %s: %s", output_path, exc)
+            raise
+
+        return output_path
+
+    def _normalize_schema(self, data: pd.DataFrame) -> pd.DataFrame:
+        frame = data.copy()
+
+        if isinstance(frame.columns, pd.MultiIndex):
+            frame.columns = frame.columns.get_level_values(0)
+
+        if "Date" not in frame.columns:
+            frame = frame.reset_index()
+
+        if "Adj Close" in frame.columns and "Close" not in frame.columns:
+            frame = frame.rename(columns={"Adj Close": "Close"})
+
+        missing = [col for col in ["Date", "Open", "High", "Low", "Close"] if col not in frame.columns]
+        if missing:
+            raise ValueError(f"Downloaded data missing required columns: {missing}")
+
+        if "Volume" not in frame.columns:
+            frame["Volume"] = 0
+
+        normalized = frame[REQUIRED_COLUMNS].copy()
+        normalized["Date"] = pd.to_datetime(normalized["Date"], errors="coerce")
+
+        bad_dates = normalized["Date"].isna().sum()
+        if bad_dates:
+            self.logger.warning("Dropping %d rows with invalid Date", bad_dates)
+            normalized = normalized.dropna(subset=["Date"])
+
+        for col in ["Open", "High", "Low", "Close", "Volume"]:
+            normalized[col] = pd.to_numeric(normalized[col], errors="coerce")
+
+        before_drop = len(normalized)
+        normalized = normalized.dropna(subset=["Open", "High", "Low", "Close"])
+        dropped = before_drop - len(normalized)
+        if dropped:
+            self.logger.warning("Dropped %d rows with invalid OHLC values", dropped)
+
+        normalized = normalized.sort_values("Date").drop_duplicates(subset=["Date"]).reset_index(drop=True)
+        return normalized
+
+
+if __name__ == "__main__":
+    downloader = HistoricalDataDownloader()
+    df = downloader.fetch_history("TSLA", "2020-01-01", "2024-01-01", interval="1d")
+    print(df.tail())

--- a/v3_pipeline/features/indicators.py
+++ b/v3_pipeline/features/indicators.py
@@ -1,0 +1,164 @@
+import logging
+import sys
+from typing import List
+
+import numpy as np
+import pandas as pd
+
+REQUIRED_COLUMNS = ["Date", "Open", "High", "Low", "Close", "Volume"]
+
+
+def _build_stderr_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler(sys.stderr)
+    formatter = logging.Formatter(
+        "%(asctime)s | %(name)s | %(levelname)s | %(message)s",
+        "%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.propagate = False
+    return logger
+
+
+class TechnicalIndicatorGenerator:
+    """Feature module for generating technical indicators from OHLCV DataFrames."""
+
+    def __init__(self):
+        self.logger = _build_stderr_logger(self.__class__.__name__)
+        try:
+            import talib as ta  # type: ignore
+
+            self.ta = ta
+            self.use_talib = True
+            self.logger.info("TA-Lib backend enabled")
+        except Exception as exc:  # fallback path for environments without TA-Lib
+            self.ta = None
+            self.use_talib = False
+            self.logger.warning("TA-Lib unavailable, using pandas fallback indicators: %s", exc)
+
+    def generate(self, data: pd.DataFrame) -> pd.DataFrame:
+        self._validate_input(data)
+
+        df = data.copy()
+        df["Date"] = pd.to_datetime(df["Date"], errors="coerce")
+        df = df.sort_values("Date").reset_index(drop=True)
+
+        if self.use_talib:
+            featured = self._with_talib(df)
+        else:
+            featured = self._fallback(df)
+
+        generated_columns = [c for c in featured.columns if c not in REQUIRED_COLUMNS]
+        self.logger.info("Generated %d indicators", len(generated_columns))
+        return featured
+
+    def _validate_input(self, data: pd.DataFrame) -> None:
+        missing = [col for col in REQUIRED_COLUMNS if col not in data.columns]
+        if missing:
+            msg = f"Input data missing required columns: {missing}"
+            self.logger.error(msg)
+            raise ValueError(msg)
+
+    def _with_talib(self, df: pd.DataFrame) -> pd.DataFrame:
+        close = df["Close"].astype(float).values
+        high = df["High"].astype(float).values
+        low = df["Low"].astype(float).values
+        volume = df["Volume"].astype(float).values
+
+        df["SMA_5"] = self.ta.SMA(close, timeperiod=5)
+        df["SMA_10"] = self.ta.SMA(close, timeperiod=10)
+        df["SMA_20"] = self.ta.SMA(close, timeperiod=20)
+        df["EMA_12"] = self.ta.EMA(close, timeperiod=12)
+        df["EMA_26"] = self.ta.EMA(close, timeperiod=26)
+        df["RSI_14"] = self.ta.RSI(close, timeperiod=14)
+
+        macd, macd_signal, macd_hist = self.ta.MACD(close, fastperiod=12, slowperiod=26, signalperiod=9)
+        df["MACD"] = macd
+        df["MACD_SIGNAL"] = macd_signal
+        df["MACD_HIST"] = macd_hist
+
+        upper, middle, lower = self.ta.BBANDS(close, timeperiod=20, nbdevup=2, nbdevdn=2)
+        df["BB_UPPER"] = upper
+        df["BB_MIDDLE"] = middle
+        df["BB_LOWER"] = lower
+
+        df["ATR_14"] = self.ta.ATR(high, low, close, timeperiod=14)
+        df["ADX_14"] = self.ta.ADX(high, low, close, timeperiod=14)
+        df["CCI_14"] = self.ta.CCI(high, low, close, timeperiod=14)
+        df["MFI_14"] = self.ta.MFI(high, low, close, volume, timeperiod=14)
+        df["OBV"] = self.ta.OBV(close, volume)
+        df["ROC_10"] = self.ta.ROC(close, timeperiod=10)
+        df["WILLR_14"] = self.ta.WILLR(high, low, close, timeperiod=14)
+        return df
+
+    def _fallback(self, df: pd.DataFrame) -> pd.DataFrame:
+        close = df["Close"].astype(float)
+        high = df["High"].astype(float)
+        low = df["Low"].astype(float)
+        volume = df["Volume"].astype(float)
+
+        df["SMA_5"] = close.rolling(5).mean()
+        df["SMA_10"] = close.rolling(10).mean()
+        df["SMA_20"] = close.rolling(20).mean()
+        df["EMA_12"] = close.ewm(span=12, adjust=False).mean()
+        df["EMA_26"] = close.ewm(span=26, adjust=False).mean()
+
+        delta = close.diff()
+        gain = delta.clip(lower=0).rolling(14).mean()
+        loss = (-delta.clip(upper=0)).rolling(14).mean()
+        rs = gain / loss.replace(0, np.nan)
+        df["RSI_14"] = 100 - (100 / (1 + rs))
+
+        macd = df["EMA_12"] - df["EMA_26"]
+        signal = macd.ewm(span=9, adjust=False).mean()
+        df["MACD"] = macd
+        df["MACD_SIGNAL"] = signal
+        df["MACD_HIST"] = macd - signal
+
+        mid = close.rolling(20).mean()
+        std = close.rolling(20).std()
+        df["BB_UPPER"] = mid + 2 * std
+        df["BB_MIDDLE"] = mid
+        df["BB_LOWER"] = mid - 2 * std
+
+        tr_components = pd.concat(
+            [(high - low), (high - close.shift()).abs(), (low - close.shift()).abs()],
+            axis=1,
+        )
+        tr = tr_components.max(axis=1)
+        df["ATR_14"] = tr.rolling(14).mean()
+
+        up_move = high.diff()
+        down_move = -low.diff()
+        plus_dm = np.where((up_move > down_move) & (up_move > 0), up_move, 0.0)
+        minus_dm = np.where((down_move > up_move) & (down_move > 0), down_move, 0.0)
+        tr14 = tr.rolling(14).sum()
+        plus_di = 100 * pd.Series(plus_dm, index=df.index).rolling(14).sum() / tr14
+        minus_di = 100 * pd.Series(minus_dm, index=df.index).rolling(14).sum() / tr14
+        dx = (100 * (plus_di - minus_di).abs() / (plus_di + minus_di)).replace([np.inf, -np.inf], np.nan)
+        df["ADX_14"] = dx.rolling(14).mean()
+
+        typical = (high + low + close) / 3
+        cci_den = 0.015 * (typical - typical.rolling(14).mean()).abs().rolling(14).mean()
+        df["CCI_14"] = (typical - typical.rolling(14).mean()) / cci_den.replace(0, np.nan)
+
+        money_flow = typical * volume
+        positive_flow = money_flow.where(typical > typical.shift(), 0.0).rolling(14).sum()
+        negative_flow = money_flow.where(typical < typical.shift(), 0.0).rolling(14).sum()
+        mfr = positive_flow / negative_flow.replace(0, np.nan)
+        df["MFI_14"] = 100 - (100 / (1 + mfr))
+
+        direction = np.sign(close.diff()).fillna(0.0)
+        df["OBV"] = (direction * volume).cumsum()
+        df["ROC_10"] = close.pct_change(10) * 100
+        highest = high.rolling(14).max()
+        lowest = low.rolling(14).min()
+        df["WILLR_14"] = -100 * (highest - close) / (highest - lowest).replace(0, np.nan)
+        return df
+
+    def indicator_columns(self, data: pd.DataFrame) -> List[str]:
+        return [col for col in data.columns if col not in REQUIRED_COLUMNS]

--- a/v3_pipeline/models/brain.py
+++ b/v3_pipeline/models/brain.py
@@ -1,0 +1,35 @@
+import torch
+from torch import nn
+
+
+class KiroLSTM(nn.Module):
+    """Configurable LSTM network for next-step price/trend prediction."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        hidden_dim: int = 64,
+        num_layers: int = 2,
+        dropout: float = 0.2,
+        output_dim: int = 1,
+    ) -> None:
+        super().__init__()
+        effective_dropout = dropout if num_layers > 1 else 0.0
+
+        self.lstm = nn.LSTM(
+            input_size=input_dim,
+            hidden_size=hidden_dim,
+            num_layers=num_layers,
+            batch_first=True,
+            dropout=effective_dropout,
+        )
+        self.dropout = nn.Dropout(dropout)
+        self.fc = nn.Linear(hidden_dim, output_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x shape: [batch_size, sequence_length, input_dim]
+        lstm_out, _ = self.lstm(x)
+        last_step = lstm_out[:, -1, :]
+        dropped = self.dropout(last_step)
+        output = self.fc(dropped)
+        return output

--- a/v3_pipeline/models/manager.py
+++ b/v3_pipeline/models/manager.py
@@ -1,0 +1,320 @@
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from v3_pipeline.data.downloader import HistoricalDataDownloader
+from v3_pipeline.features.indicators import TechnicalIndicatorGenerator
+from v3_pipeline.models.brain import KiroLSTM
+
+REQUIRED_COLUMNS = ["Date", "Open", "High", "Low", "Close", "Volume"]
+
+
+def _build_stderr_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler(sys.stderr)
+    formatter = logging.Formatter(
+        "%(asctime)s | %(name)s | %(levelname)s | %(message)s",
+        "%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.propagate = False
+    return logger
+
+
+@dataclass
+class TrainingConfig:
+    lookback: int = 60
+    target_col: str = "Close"
+    batch_size: int = 32
+    epochs: int = 10
+    lr: float = 1e-3
+    hidden_dim: int = 64
+    num_layers: int = 2
+    dropout: float = 0.2
+    output_dim: int = 1
+
+
+class DataPreparer:
+    """Convert OHLCV+indicator DataFrames into normalized LSTM tensors."""
+
+    def __init__(self, lookback: int = 60, target_col: str = "Close") -> None:
+        self.lookback = lookback
+        self.target_col = target_col
+        self.logger = _build_stderr_logger(self.__class__.__name__)
+        self.feature_columns: Optional[List[str]] = None
+        self.feature_mins: Optional[pd.Series] = None
+        self.feature_maxs: Optional[pd.Series] = None
+        self.target_min: Optional[float] = None
+        self.target_max: Optional[float] = None
+
+    def fit_transform(self, frame: pd.DataFrame) -> Tuple[torch.Tensor, torch.Tensor]:
+        clean = self._sanitize(frame)
+        features = clean.drop(columns=["Date"]).copy()
+
+        if self.target_col not in features.columns:
+            raise ValueError(f"target_col '{self.target_col}' not in data columns")
+
+        self.feature_columns = features.columns.tolist()
+        self.feature_mins = features.min(axis=0)
+        self.feature_maxs = features.max(axis=0)
+        scaled_features = self._minmax_scale(features, self.feature_mins, self.feature_maxs)
+
+        target_series = clean[self.target_col].astype(float)
+        self.target_min = float(target_series.min())
+        self.target_max = float(target_series.max())
+        scaled_target = self._scale_target(target_series)
+
+        x, y = self._windowize(scaled_features.values, scaled_target.values)
+        self.logger.info("Prepared tensors with X=%s and y=%s", tuple(x.shape), tuple(y.shape))
+        return x, y
+
+    def transform_for_inference(self, frame: pd.DataFrame) -> torch.Tensor:
+        if self.feature_columns is None or self.feature_mins is None or self.feature_maxs is None:
+            raise RuntimeError("DataPreparer is not fitted. Call fit_transform() first.")
+
+        clean = self._sanitize(frame)
+        features = clean.drop(columns=["Date"]).copy()
+
+        missing = [c for c in self.feature_columns if c not in features.columns]
+        if missing:
+            raise ValueError(f"Missing required features for inference: {missing}")
+
+        ordered = features[self.feature_columns]
+        scaled = self._minmax_scale(ordered, self.feature_mins, self.feature_maxs)
+
+        if len(scaled) < self.lookback:
+            raise ValueError(f"Need at least lookback={self.lookback} rows, got {len(scaled)}")
+
+        window = scaled.iloc[-self.lookback :].values.astype(np.float32)
+        return torch.tensor(window).unsqueeze(0)
+
+    def inverse_scale_target(self, value: float) -> float:
+        if self.target_min is None or self.target_max is None:
+            return value
+        span = self.target_max - self.target_min
+        if span == 0:
+            return self.target_min
+        return float(value * span + self.target_min)
+
+    def _sanitize(self, frame: pd.DataFrame) -> pd.DataFrame:
+        missing = [col for col in REQUIRED_COLUMNS if col not in frame.columns]
+        if missing:
+            raise ValueError(f"Input frame missing required OHLCV columns: {missing}")
+
+        clean = frame.copy()
+        clean["Date"] = pd.to_datetime(clean["Date"], errors="coerce")
+        clean = clean.dropna(subset=["Date"]).sort_values("Date").drop_duplicates(subset=["Date"])
+
+        numeric_cols = [c for c in clean.columns if c != "Date"]
+        for col in numeric_cols:
+            clean[col] = pd.to_numeric(clean[col], errors="coerce")
+
+        clean = clean.dropna().reset_index(drop=True)
+
+        if len(clean) <= self.lookback:
+            raise ValueError(
+                f"Not enough clean rows ({len(clean)}) for lookback={self.lookback}."
+            )
+        return clean
+
+    def _windowize(self, feature_array: np.ndarray, target_array: np.ndarray) -> Tuple[torch.Tensor, torch.Tensor]:
+        x_list, y_list = [], []
+        for idx in range(self.lookback, len(feature_array)):
+            x_list.append(feature_array[idx - self.lookback : idx])
+            y_list.append(target_array[idx])
+
+        x = torch.tensor(np.asarray(x_list), dtype=torch.float32)
+        y = torch.tensor(np.asarray(y_list).reshape(-1, 1), dtype=torch.float32)
+        return x, y
+
+    @staticmethod
+    def _minmax_scale(values: pd.DataFrame, mins: pd.Series, maxs: pd.Series) -> pd.DataFrame:
+        denom = (maxs - mins).replace(0, 1.0)
+        scaled = (values - mins) / denom
+        return scaled.clip(lower=0.0, upper=1.0)
+
+    def _scale_target(self, target: pd.Series) -> pd.Series:
+        if self.target_min is None or self.target_max is None:
+            raise RuntimeError("Target scaler not initialized")
+        span = self.target_max - self.target_min
+        if span == 0:
+            return pd.Series(np.zeros(len(target)), index=target.index, dtype=float)
+        return (target - self.target_min) / span
+
+
+class ModelManager:
+    def __init__(
+        self,
+        model: KiroLSTM,
+        data_preparer: DataPreparer,
+        device: Optional[str] = None,
+        model_dir: str = "v3_pipeline/models/trained_models",
+    ) -> None:
+        self.logger = _build_stderr_logger(self.__class__.__name__)
+        self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        self.model = model.to(self.device)
+        self.data_preparer = data_preparer
+        self.model_dir = Path(model_dir)
+        self.model_dir.mkdir(parents=True, exist_ok=True)
+
+    def build_dataloader(
+        self,
+        frame: pd.DataFrame,
+        batch_size: int = 32,
+        shuffle: bool = True,
+    ) -> DataLoader:
+        x, y = self.data_preparer.fit_transform(frame)
+        dataset = TensorDataset(x, y)
+        return DataLoader(dataset, batch_size=batch_size, shuffle=shuffle)
+
+    def train(self, dataloader: DataLoader, epochs: int = 10, lr: float = 1e-3) -> List[float]:
+        criterion = nn.MSELoss()
+        optimizer = torch.optim.Adam(self.model.parameters(), lr=lr)
+
+        losses: List[float] = []
+        self.model.train()
+
+        for epoch in range(1, epochs + 1):
+            epoch_losses: List[float] = []
+            for batch_x, batch_y in dataloader:
+                batch_x = batch_x.to(self.device)
+                batch_y = batch_y.to(self.device)
+
+                optimizer.zero_grad()
+                pred = self.model(batch_x)
+                loss = criterion(pred, batch_y)
+                loss.backward()
+                optimizer.step()
+
+                epoch_losses.append(float(loss.item()))
+
+            mean_loss = float(np.mean(epoch_losses)) if epoch_losses else float("nan")
+            losses.append(mean_loss)
+            self.logger.info("Epoch %d/%d | MSE=%.6f", epoch, epochs, mean_loss)
+
+        return losses
+
+    def predict(self, latest_data_window: pd.DataFrame) -> float:
+        self.model.eval()
+        with torch.no_grad():
+            x = self.data_preparer.transform_for_inference(latest_data_window).to(self.device)
+            scaled_pred = float(self.model(x).cpu().numpy().ravel()[0])
+            pred = self.data_preparer.inverse_scale_target(scaled_pred)
+            self.logger.info("Prediction (scaled=%.6f, inverse=%.6f)", scaled_pred, pred)
+            return pred
+
+    def save(self, model_name: str) -> Path:
+        target = self.model_dir / f"{model_name}.pth"
+        payload = {
+            "model_state_dict": self.model.state_dict(),
+            "lookback": self.data_preparer.lookback,
+            "target_col": self.data_preparer.target_col,
+            "feature_columns": self.data_preparer.feature_columns,
+            "feature_mins": self.data_preparer.feature_mins.to_dict() if self.data_preparer.feature_mins is not None else None,
+            "feature_maxs": self.data_preparer.feature_maxs.to_dict() if self.data_preparer.feature_maxs is not None else None,
+            "target_min": self.data_preparer.target_min,
+            "target_max": self.data_preparer.target_max,
+        }
+        torch.save(payload, target)
+        self.logger.info("Saved model checkpoint to %s", target)
+        return target
+
+    def load(self, model_name: str) -> None:
+        source = self.model_dir / f"{model_name}.pth"
+        payload = torch.load(source, map_location=self.device)
+        self.model.load_state_dict(payload["model_state_dict"])
+
+        self.data_preparer.lookback = int(payload.get("lookback", self.data_preparer.lookback))
+        self.data_preparer.target_col = str(payload.get("target_col", self.data_preparer.target_col))
+
+        feature_columns = payload.get("feature_columns")
+        if feature_columns is not None:
+            self.data_preparer.feature_columns = list(feature_columns)
+
+        feature_mins = payload.get("feature_mins")
+        feature_maxs = payload.get("feature_maxs")
+        if feature_mins is not None:
+            self.data_preparer.feature_mins = pd.Series(feature_mins)
+        if feature_maxs is not None:
+            self.data_preparer.feature_maxs = pd.Series(feature_maxs)
+
+        self.data_preparer.target_min = payload.get("target_min")
+        self.data_preparer.target_max = payload.get("target_max")
+
+        self.model.eval()
+        self.logger.info("Loaded model checkpoint from %s", source)
+
+
+def train_symbol_pipeline(
+    symbol: str,
+    start_date: str,
+    end_date: str,
+    config: Optional[TrainingConfig] = None,
+) -> Tuple[ModelManager, List[float], float]:
+    cfg = config or TrainingConfig()
+
+    logger = _build_stderr_logger("KiroTrainPipeline")
+    downloader = HistoricalDataDownloader()
+    feature_gen = TechnicalIndicatorGenerator()
+
+    logger.info("Running integrated train pipeline for %s", symbol)
+    ohlcv = downloader.fetch_history(symbol, start_date, end_date, interval="1d", save=True)
+    featured = feature_gen.generate(ohlcv)
+    featured = featured.dropna().reset_index(drop=True)
+
+    preparer = DataPreparer(lookback=cfg.lookback, target_col=cfg.target_col)
+    sample_x, _ = preparer.fit_transform(featured)
+
+    model = KiroLSTM(
+        input_dim=sample_x.shape[-1],
+        hidden_dim=cfg.hidden_dim,
+        num_layers=cfg.num_layers,
+        dropout=cfg.dropout,
+        output_dim=cfg.output_dim,
+    )
+
+    manager = ModelManager(model=model, data_preparer=preparer)
+    dataloader = DataLoader(TensorDataset(sample_x, _), batch_size=cfg.batch_size, shuffle=True)
+
+    losses = manager.train(dataloader, epochs=cfg.epochs, lr=cfg.lr)
+    manager.save(f"{symbol}_kiro_lstm")
+    prediction = manager.predict(featured)
+
+    return manager, losses, prediction
+
+
+if __name__ == "__main__":
+    # Example test-training session
+    training_config = TrainingConfig(
+        lookback=30,
+        epochs=3,
+        batch_size=16,
+        lr=1e-3,
+        hidden_dim=32,
+        num_layers=2,
+        dropout=0.2,
+    )
+    try:
+        _, losses, pred = train_symbol_pipeline(
+            symbol="TSLA",
+            start_date="2022-01-01",
+            end_date="2024-01-01",
+            config=training_config,
+        )
+        print(f"Training complete. Final loss={losses[-1]:.6f}, next prediction={pred:.4f}")
+    except Exception as exc:
+        _build_stderr_logger("KiroTrainPipelineMain").exception("Training session failed: %s", exc)
+        raise

--- a/v3_pipeline/risk/manager.py
+++ b/v3_pipeline/risk/manager.py
@@ -1,0 +1,77 @@
+import logging
+import sys
+from dataclasses import dataclass
+
+
+def _build_stderr_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler(sys.stderr)
+    formatter = logging.Formatter(
+        "%(asctime)s | %(name)s | %(levelname)s | %(message)s",
+        "%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.propagate = False
+    return logger
+
+
+@dataclass
+class RiskConfig:
+    max_drawdown: float = 0.20
+    max_position_fraction: float = 0.05
+    trailing_stop_pct: float = 0.05
+
+
+class RiskController:
+    """Risk guardrails for live/backtest trading decisions."""
+
+    def __init__(self, config: RiskConfig | None = None) -> None:
+        self.config = config or RiskConfig()
+        self.logger = _build_stderr_logger(self.__class__.__name__)
+
+    def circuit_breaker_triggered(self, equity_peak: float, current_equity: float) -> bool:
+        if equity_peak <= 0:
+            return False
+        drawdown = max(0.0, (equity_peak - current_equity) / equity_peak)
+        triggered = drawdown >= self.config.max_drawdown
+        if triggered:
+            self.logger.warning(
+                "Circuit breaker triggered. drawdown=%.2f%% (limit=%.2f%%)",
+                drawdown * 100,
+                self.config.max_drawdown * 100,
+            )
+        return triggered
+
+    def calculate_position_size(self, account_value: float, price: float) -> int:
+        if account_value <= 0 or price <= 0:
+            return 0
+        budget = account_value * self.config.max_position_fraction
+        qty = int(budget // price)
+        self.logger.info(
+            "Calculated position size qty=%d (account_value=%.2f, price=%.2f)",
+            qty,
+            account_value,
+            price,
+        )
+        return max(qty, 0)
+
+    def trailing_stop_price(self, highest_price_since_entry: float) -> float:
+        if highest_price_since_entry <= 0:
+            return 0.0
+        stop = highest_price_since_entry * (1 - self.config.trailing_stop_pct)
+        return float(stop)
+
+    def should_stop_out(self, current_price: float, highest_price_since_entry: float) -> bool:
+        stop = self.trailing_stop_price(highest_price_since_entry)
+        hit = current_price <= stop if stop > 0 else False
+        if hit:
+            self.logger.warning(
+                "Trailing stop hit. current=%.4f <= stop=%.4f",
+                current_price,
+                stop,
+            )
+        return hit


### PR DESCRIPTION
### Motivation
- Provide a complete end-to-end trading pipeline for data acquisition, feature generation, model training/inference, risk management, live execution and backtesting.
- Support both TA-Lib and pandas fallbacks for indicator generation to make feature engineering robust across environments.
- Introduce a configurable LSTM-based model and utilities for preparing time-series windows, training, saving, and loading models for inference.
- Add adapters for live connectivity (`FutuConnector`) and a live main loop to bridge real-time quotes -> features -> model -> execution.

### Description
- Added a historical data acquisition module `v3_pipeline/data/downloader.py` with robust yfinance download, schema normalization, and `save_history` support for `parquet`/`csv` files.
- Implemented technical feature generator `v3_pipeline/features/indicators.py` that uses TA-Lib when available and provides a pandas fallback implementing many indicators (`SMA`, `EMA`, `RSI`, `MACD`, `BBANDS`, `ATR`, `ADX`, `CCI`, `MFI`, `OBV`, `ROC`, `WILLR`).
- Added model components: `v3_pipeline/models/brain.py` containing `KiroLSTM` and `v3_pipeline/models/manager.py` containing `DataPreparer`, `ModelManager`, and an integrated `train_symbol_pipeline` including save/load and prediction utilities.
- Introduced risk controls in `v3_pipeline/risk/manager.py` exposing circuit breaker, position sizing, and trailing stop logic via `RiskController`.
- Added live integration pieces: `v3_pipeline/core/futu_connector.py` as a lightweight Futu OpenAPI adapter, and `v3_pipeline/core/main_loop.py` for a 24/7-style live loop that uses model, risk controller, feature generator and notifier hooks.
- Implemented a backtesting engine in `v3_pipeline/backtest/engine.py` that wires `backtrader` strategy via `KiroStrategyFactory`, adds analyzers (`Returns`, `SharpeRatio`, `DrawDown`) and returns a summary including `total_return`, `sharpe_ratio`, `max_drawdown`, and `final_value`.
- Consistent logging helper `_build_stderr_logger` was included across modules and small `__main__` example/test harnesses were added to downloader and manager for manual runs.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aea24ee07c8328ba55fb733e8c8d1e)