### PR TITLE
Add WebSocket log terminal (kiro_bridge) and improve FutuConnector quote handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kiro Bridge Tactical Terminal</title>
+  <style>
+    body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b0f14; color: #c9d1d9; }
+    .container { max-width: 1100px; margin: 24px auto; padding: 0 16px; }
+    .terminal { background: #0d1117; border: 1px solid #30363d; border-radius: 12px; padding: 16px; box-shadow: 0 0 40px rgba(56,139,253,.12); }
+    .header { display:flex; justify-content:space-between; align-items:center; margin-bottom:12px; }
+    .title { font-size: 20px; font-weight: 700; }
+    .subtitle { color:#8b949e; font-size: 13px; margin-top:4px; }
+    .toggle { display:flex; gap:8px; align-items:center; color:#8b949e; font-size:13px; }
+    .log-box { height: 60vh; overflow-y: auto; background:#010409; border: 1px solid #21262d; border-radius: 10px; padding: 10px; }
+    .line { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; margin: 0; }
+    .warning { color: #e3b341; }
+    .success { color: #3fb950; }
+    .danger { color: #f85149; }
+    .meta { color: #7d8590; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <section class="terminal">
+      <div class="header">
+        <div>
+          <div class="title">Tactical Terminal (戰術終端)</div>
+          <div class="subtitle" id="status">Connecting...</div>
+        </div>
+        <label class="toggle">
+          <input id="autoScroll" type="checkbox" checked />
+          Auto-Scroll (自動滾動)
+        </label>
+      </div>
+      <div id="logBox" class="log-box"></div>
+    </section>
+  </div>
+
+  <script>
+    const logBox = document.getElementById('logBox');
+    const statusEl = document.getElementById('status');
+    const autoScrollEl = document.getElementById('autoScroll');
+    let ws;
+    let reconnectMs = 1000;
+
+    const classify = (line) => {
+      if (line.includes('[ERROR]') || line.includes('Exception')) return 'danger';
+      if (line.includes('[TRADE]')) return 'success';
+      if (line.includes('[SIGNAL]')) return 'warning';
+      return 'meta';
+    };
+
+    const appendLine = (line) => {
+      if (!line || line.includes('[HEARTBEAT]')) return;
+      const row = document.createElement('p');
+      row.className = `line ${classify(line)}`;
+      row.textContent = line;
+      logBox.appendChild(row);
+
+      if (logBox.children.length > 2000) {
+        logBox.removeChild(logBox.firstChild);
+      }
+
+      if (autoScrollEl.checked) {
+        logBox.scrollTop = logBox.scrollHeight;
+      }
+    };
+
+    const wsUrl = () => {
+      const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+      return `${proto}://${location.host}/ws/v3_logs`;
+    };
+
+    const connect = () => {
+      ws = new WebSocket(wsUrl());
+      statusEl.textContent = 'Connecting to /ws/v3_logs...';
+
+      ws.onopen = () => {
+        statusEl.textContent = '✅ Live connected';
+        reconnectMs = 1000;
+      };
+
+      ws.onmessage = (event) => appendLine(event.data);
+
+      ws.onclose = () => {
+        statusEl.textContent = `⚠️ Disconnected, retry in ${Math.floor(reconnectMs/1000)}s`;
+        setTimeout(connect, reconnectMs);
+        reconnectMs = Math.min(reconnectMs * 2, 10000);
+      };
+
+      ws.onerror = () => ws.close();
+    };
+
+    connect();
+  </script>
+</body>
+</html>

--- a/kiro_bridge.py
+++ b/kiro_bridge.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import asyncio
+import os
+from collections import deque
+from pathlib import Path
+from typing import AsyncIterator
+
+import aiofiles
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import FileResponse, JSONResponse
+
+APP_HOST = os.getenv("KIRO_BRIDGE_HOST", "0.0.0.0")
+APP_PORT = int(os.getenv("KIRO_BRIDGE_PORT", "18888"))
+LOG_PATH = Path(
+    os.getenv(
+        "V3_LOG_PATH",
+        "/home/tsukii0607/.openclaw/workspace/skills/futu-api/v3_pipeline/logs/v3_live_trade.log",
+    )
+)
+
+app = FastAPI(title="Kiro Bridge", version="1.0.0")
+
+
+@app.get("/")
+async def index() -> FileResponse:
+    return FileResponse("index.html")
+
+
+@app.get("/health")
+async def health() -> JSONResponse:
+    return JSONResponse(
+        {
+            "ok": True,
+            "log_exists": LOG_PATH.exists(),
+            "log_path": str(LOG_PATH),
+        }
+    )
+
+
+def tail_lines(path: Path, max_lines: int = 120) -> list[str]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        return [line.rstrip("\n") for line in deque(handle, maxlen=max_lines)]
+
+
+async def follow_log(path: Path, poll_seconds: float = 0.4) -> AsyncIterator[str]:
+    while not path.exists():
+        await asyncio.sleep(poll_seconds)
+
+    stream = await aiofiles.open(path, "r", encoding="utf-8", errors="replace")
+    await stream.seek(0, os.SEEK_END)
+    last_inode = path.stat().st_ino
+
+    try:
+        while True:
+            line = await stream.readline()
+            if line:
+                yield line.rstrip("\n")
+                continue
+
+            yield ""
+            await asyncio.sleep(poll_seconds)
+
+            if path.exists() and path.stat().st_ino != last_inode:
+                await stream.close()
+                stream = await aiofiles.open(path, "r", encoding="utf-8", errors="replace")
+                last_inode = path.stat().st_ino
+    finally:
+        await stream.close()
+
+
+@app.websocket("/ws/v3_logs")
+async def ws_v3_logs(ws: WebSocket) -> None:
+    await ws.accept()
+    for line in tail_lines(LOG_PATH):
+        await ws.send_text(line)
+
+    try:
+        async for new_line in follow_log(LOG_PATH):
+            if new_line:
+                await ws.send_text(new_line)
+            else:
+                await ws.send_text("[HEARTBEAT] ws_alive")
+    except WebSocketDisconnect:
+        return
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("kiro_bridge:app", host=APP_HOST, port=APP_PORT, reload=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 futu-api>=9.0
 pandas>=1.0
+fastapi>=0.110
+uvicorn>=0.29
+aiofiles>=23.2

--- a/scripts/start_kiro_bridge.sh
+++ b/scripts/start_kiro_bridge.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+export KIRO_BRIDGE_HOST="${KIRO_BRIDGE_HOST:-0.0.0.0}"
+export KIRO_BRIDGE_PORT="${KIRO_BRIDGE_PORT:-18888}"
+export V3_LOG_PATH="${V3_LOG_PATH:-/home/tsukii0607/.openclaw/workspace/skills/futu-api/v3_pipeline/logs/v3_live_trade.log}"
+
+python -m uvicorn kiro_bridge:app --host "$KIRO_BRIDGE_HOST" --port "$KIRO_BRIDGE_PORT"

--- a/v3_pipeline/core/futu_connector.py
+++ b/v3_pipeline/core/futu_connector.py
@@ -105,14 +105,15 @@ class FutuConnector:
             raise RuntimeError("Futu SDK not loaded. Call connect() first.")
         return getattr(self.ft.TrdEnv, self.config.trd_env, self.ft.TrdEnv.SIMULATE)
 
-    def _safe_trade_call(self, method_name: str, **kwargs):
+    def _safe_trade_call(self, method_name: str, include_trd_env: bool = True, **kwargs):
         if self.trade_ctx is None or self.ft is None:
             raise RuntimeError("FutuConnector not connected")
         method = getattr(self.trade_ctx, method_name)
-        trd_env = self._resolved_trd_env()
 
         try:
-            ret, data = method(trd_env=trd_env, **kwargs)
+            if include_trd_env:
+                kwargs["trd_env"] = self._resolved_trd_env()
+            ret, data = method(**kwargs)
             if ret != self.ft.RET_OK:
                 raise RuntimeError(f"{method_name} failed: {data}")
             return data
@@ -125,7 +126,7 @@ class FutuConnector:
         Returns DataFrame with account metadata, including acc_id, account type and status.
         """
         try:
-            data = self._safe_trade_call("get_acc_list")
+            data = self._safe_trade_call("get_acc_list", include_trd_env=False)
             if data is None:
                 self.discovered_accounts = pd.DataFrame()
                 return self.discovered_accounts
@@ -179,27 +180,68 @@ class FutuConnector:
             self.logger.warning("Futu heartbeat failed: %s", exc)
             return False
 
-    def get_latest_quote(self, symbol: str) -> dict:
-        if self.quote_ctx is None or self.ft is None:
-            raise RuntimeError("FutuConnector not connected")
+    def _quote_dict(self, open_price: float, high_price: float, low_price: float, close_price: float, volume: float) -> dict:
+        return {
+            "Date": pd.Timestamp.now(),
+            "Open": float(open_price),
+            "High": float(high_price),
+            "Low": float(low_price),
+            "Close": float(close_price),
+            "Volume": float(volume),
+        }
 
-        code = f"{self.config.market_prefix}.{symbol}"
+    def _get_latest_quote_yfinance(self, symbol: str) -> dict:
         try:
+            import yfinance as yf
+        except Exception as exc:
+            raise RuntimeError(f"yfinance unavailable in current environment: {exc}") from exc
+
+        ticker = yf.Ticker(symbol)
+        hist = ticker.history(period="1d", interval="1m")
+        if hist.empty:
+            hist = ticker.history(period="5d", interval="1d")
+        if hist.empty:
+            raise RuntimeError(f"yfinance returned empty data for {symbol}")
+
+        row = hist.iloc[-1]
+        close_price = float(row.get("Close", 0.0))
+        open_price = float(row.get("Open", close_price))
+        high_price = float(row.get("High", close_price))
+        low_price = float(row.get("Low", close_price))
+        volume = float(row.get("Volume", 0.0))
+
+        quote = self._quote_dict(open_price, high_price, low_price, close_price, volume)
+        self.logger.warning("[YFINANCE] Quote fallback in use for %s: close=%.4f", symbol, quote["Close"])
+        return quote
+
+    def get_latest_quote(self, symbol: str) -> dict:
+        code = f"{self.config.market_prefix}.{symbol}"
+
+        try:
+            if self.quote_ctx is None or self.ft is None:
+                raise RuntimeError("FutuConnector not connected")
+
             ret, df = self.quote_ctx.get_stock_quote([code])
             if ret != self.ft.RET_OK or df.empty:
                 raise RuntimeError(f"Failed to fetch quote for {code}: {df}")
 
             row = df.iloc[0]
-            return {
-                "Date": pd.Timestamp.now(),
-                "Open": float(row.get("open_price", row.get("last_price", 0.0))),
-                "High": float(row.get("high_price", row.get("last_price", 0.0))),
-                "Low": float(row.get("low_price", row.get("last_price", 0.0))),
-                "Close": float(row.get("last_price", 0.0)),
-                "Volume": float(row.get("volume", 0.0)),
-            }
-        except Exception as exc:
-            raise RuntimeError(f"Quote query failed for {code}: {exc}") from exc
+            close_price = float(row.get("last_price", 0.0))
+            quote = self._quote_dict(
+                open_price=float(row.get("open_price", close_price)),
+                high_price=float(row.get("high_price", close_price)),
+                low_price=float(row.get("low_price", close_price)),
+                close_price=close_price,
+                volume=float(row.get("volume", 0.0)),
+            )
+            self.logger.info("[FUTU] Quote for %s: close=%.4f", code, quote["Close"])
+            return quote
+        except Exception as futu_exc:
+            self.logger.warning("[FUTU] Quote query failed for %s, fallback to yfinance: %s", code, futu_exc)
+            try:
+                return self._get_latest_quote_yfinance(symbol)
+            except Exception as yf_exc:
+                raise RuntimeError(f"Quote query failed for {code}. Futu error={futu_exc}; yfinance error={yf_exc}") from yf_exc
 
     def get_sync_assets(self) -> dict:
         data = self._safe_trade_call("accinfo_query", **self._account_kwargs())

--- a/v3_pipeline/core/main_loop.py
+++ b/v3_pipeline/core/main_loop.py
@@ -180,6 +180,11 @@ class LiveTradingLoop:
     def _execute(self, side: str, qty: int, price: float, reason: str) -> None:
         self.logger.info("Execute %s qty=%d price=%.4f reason=%s", side, qty, price, reason)
 
+        if self.config.auto_trade and not self.config.paper_trading:
+            self.futu_connector.place_order(self.config.symbol, qty, side, price)
+        else:
+            self.logger.info("Paper trading mode: simulated %s %d %s", side, qty, self.config.symbol)
+
         if side == "BUY":
             self.position_qty += qty
             self.highest_price_since_entry = price
@@ -187,11 +192,6 @@ class LiveTradingLoop:
             self.position_qty = max(0, self.position_qty - qty)
             if self.position_qty == 0:
                 self.highest_price_since_entry = 0.0
-
-        if self.config.auto_trade and not self.config.paper_trading:
-            self.futu_connector.place_order(self.config.symbol, qty, side, price)
-        else:
-            self.logger.info("Paper trading mode: simulated %s %d %s", side, qty, self.config.symbol)
 
     def _notify(self, message: str) -> None:
         self.logger.info(message)


### PR DESCRIPTION
### Motivation
- Provide a lightweight live-tail terminal UI for v3 trading logs served over WebSocket for real-time observability.
- Expose the filesystem log via a small bridge service so logs can be consumed in-browser without direct file access.
- Make quote fetching more robust by falling back to `yfinance` when Futu quote queries fail and make trade API calls more flexible.
- Add an easy start script and required runtime dependencies for the bridge service.

### Description
- Added `index.html` which implements a terminal-style UI with auto-scroll and a WebSocket client that connects to `/ws/v3_logs` and classifies lines into `warning`, `success`, `danger`, and `meta` categories.
- Added `kiro_bridge.py`, a FastAPI application that serves `/` and a WebSocket endpoint `/ws/v3_logs`, implements `tail_lines` and `follow_log` to stream new lines (with heartbeat messages), and reads configuration from `V3_LOG_PATH`, `KIRO_BRIDGE_HOST`, and `KIRO_BRIDGE_PORT` environment variables.
- Added `scripts/start_kiro_bridge.sh` to launch the bridge via `uvicorn` with environment-variable defaults.
- Updated `requirements.txt` to include `fastapi`, `uvicorn`, and `aiofiles` required by the bridge.
- Updated `v3_pipeline/core/futu_connector.py` to change `_safe_trade_call` signature to accept `include_trd_env`, call `get_acc_list` with `include_trd_env=False`, add `_quote_dict` and `_get_latest_quote_yfinance` helpers, and make `get_latest_quote` use the Futu API with a logged fallback to `yfinance` on error.
- Updated `v3_pipeline/core/main_loop.py` to call `place_order` when `auto_trade` is enabled before updating the in-memory `position_qty`, and preserve simulated logging when in paper trading mode.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aed01c88e88328beca1fda904207a8)