### PR TITLE
Add Kiro Bridge websocket log viewer and refactor live loop for multi-symbol strategies

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kiro Bridge Tactical Terminal</title>
+  <style>
+    body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b0f14; color: #c9d1d9; }
+    .container { max-width: 1100px; margin: 24px auto; padding: 0 16px; }
+    .terminal { background: #0d1117; border: 1px solid #30363d; border-radius: 12px; padding: 16px; box-shadow: 0 0 40px rgba(56,139,253,.12); }
+    .header { display:flex; justify-content:space-between; align-items:center; margin-bottom:12px; }
+    .title { font-size: 20px; font-weight: 700; }
+    .subtitle { color:#8b949e; font-size: 13px; margin-top:4px; }
+    .toggle { display:flex; gap:8px; align-items:center; color:#8b949e; font-size:13px; }
+    .log-box { height: 60vh; overflow-y: auto; background:#010409; border: 1px solid #21262d; border-radius: 10px; padding: 10px; }
+    .line { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; margin: 0; }
+    .warning { color: #e3b341; }
+    .success { color: #3fb950; }
+    .danger { color: #f85149; }
+    .meta { color: #7d8590; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <section class="terminal">
+      <div class="header">
+        <div>
+          <div class="title">Tactical Terminal (戰術終端)</div>
+          <div class="subtitle" id="status">Connecting...</div>
+        </div>
+        <label class="toggle">
+          <input id="autoScroll" type="checkbox" checked />
+          Auto-Scroll (自動滾動)
+        </label>
+      </div>
+      <div id="logBox" class="log-box"></div>
+    </section>
+  </div>
+
+  <script>
+    const logBox = document.getElementById('logBox');
+    const statusEl = document.getElementById('status');
+    const autoScrollEl = document.getElementById('autoScroll');
+    let ws;
+    let reconnectMs = 1000;
+
+    const classify = (line) => {
+      if (line.includes('[ERROR]') || line.includes('Exception')) return 'danger';
+      if (line.includes('[TRADE]')) return 'success';
+      if (line.includes('[SIGNAL]')) return 'warning';
+      return 'meta';
+    };
+
+    const appendLine = (line) => {
+      if (!line || line.includes('[HEARTBEAT]')) return;
+      const row = document.createElement('p');
+      row.className = `line ${classify(line)}`;
+      row.textContent = line;
+      logBox.appendChild(row);
+
+      if (logBox.children.length > 2000) {
+        logBox.removeChild(logBox.firstChild);
+      }
+
+      if (autoScrollEl.checked) {
+        logBox.scrollTop = logBox.scrollHeight;
+      }
+    };
+
+    const wsUrl = () => {
+      const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+      return `${proto}://${location.host}/ws/v3_logs`;
+    };
+
+    const connect = () => {
+      ws = new WebSocket(wsUrl());
+      statusEl.textContent = 'Connecting to /ws/v3_logs...';
+
+      ws.onopen = () => {
+        statusEl.textContent = '✅ Live connected';
+        reconnectMs = 1000;
+      };
+
+      ws.onmessage = (event) => appendLine(event.data);
+
+      ws.onclose = () => {
+        statusEl.textContent = `⚠️ Disconnected, retry in ${Math.floor(reconnectMs/1000)}s`;
+        setTimeout(connect, reconnectMs);
+        reconnectMs = Math.min(reconnectMs * 2, 10000);
+      };
+
+      ws.onerror = () => ws.close();
+    };
+
+    connect();
+  </script>
+</body>
+</html>

--- a/kiro_bridge.py
+++ b/kiro_bridge.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import asyncio
+import os
+from collections import deque
+from pathlib import Path
+from typing import AsyncIterator
+
+import aiofiles
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import FileResponse, JSONResponse
+
+APP_HOST = os.getenv("KIRO_BRIDGE_HOST", "0.0.0.0")
+APP_PORT = int(os.getenv("KIRO_BRIDGE_PORT", "18888"))
+LOG_PATH = Path(
+    os.getenv(
+        "V3_LOG_PATH",
+        "/home/tsukii0607/.openclaw/workspace/skills/futu-api/v3_pipeline/logs/v3_live_trade.log",
+    )
+)
+
+app = FastAPI(title="Kiro Bridge", version="1.0.0")
+
+
+@app.get("/")
+async def index() -> FileResponse:
+    return FileResponse("index.html")
+
+
+@app.get("/health")
+async def health() -> JSONResponse:
+    return JSONResponse(
+        {
+            "ok": True,
+            "log_exists": LOG_PATH.exists(),
+            "log_path": str(LOG_PATH),
+        }
+    )
+
+
+def tail_lines(path: Path, max_lines: int = 120) -> list[str]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        return [line.rstrip("\n") for line in deque(handle, maxlen=max_lines)]
+
+
+async def follow_log(path: Path, poll_seconds: float = 0.4) -> AsyncIterator[str]:
+    while not path.exists():
+        await asyncio.sleep(poll_seconds)
+
+    stream = await aiofiles.open(path, "r", encoding="utf-8", errors="replace")
+    await stream.seek(0, os.SEEK_END)
+    last_inode = path.stat().st_ino
+
+    try:
+        while True:
+            line = await stream.readline()
+            if line:
+                yield line.rstrip("\n")
+                continue
+
+            yield ""
+            await asyncio.sleep(poll_seconds)
+
+            if path.exists() and path.stat().st_ino != last_inode:
+                await stream.close()
+                stream = await aiofiles.open(path, "r", encoding="utf-8", errors="replace")
+                last_inode = path.stat().st_ino
+    finally:
+        await stream.close()
+
+
+@app.websocket("/ws/v3_logs")
+async def ws_v3_logs(ws: WebSocket) -> None:
+    await ws.accept()
+    for line in tail_lines(LOG_PATH):
+        await ws.send_text(line)
+
+    try:
+        async for new_line in follow_log(LOG_PATH):
+            if new_line:
+                await ws.send_text(new_line)
+            else:
+                await ws.send_text("[HEARTBEAT] ws_alive")
+    except WebSocketDisconnect:
+        return
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("kiro_bridge:app", host=APP_HOST, port=APP_PORT, reload=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 futu-api>=9.0
 pandas>=1.0
+fastapi>=0.110
+uvicorn>=0.29
+aiofiles>=23.2

--- a/scripts/start_kiro_bridge.sh
+++ b/scripts/start_kiro_bridge.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+export KIRO_BRIDGE_HOST="${KIRO_BRIDGE_HOST:-0.0.0.0}"
+export KIRO_BRIDGE_PORT="${KIRO_BRIDGE_PORT:-18888}"
+export V3_LOG_PATH="${V3_LOG_PATH:-/home/tsukii0607/.openclaw/workspace/skills/futu-api/v3_pipeline/logs/v3_live_trade.log}"
+
+python -m uvicorn kiro_bridge:app --host "$KIRO_BRIDGE_HOST" --port "$KIRO_BRIDGE_PORT"

--- a/v3_pipeline/core/futu_connector.py
+++ b/v3_pipeline/core/futu_connector.py
@@ -105,14 +105,15 @@ class FutuConnector:
             raise RuntimeError("Futu SDK not loaded. Call connect() first.")
         return getattr(self.ft.TrdEnv, self.config.trd_env, self.ft.TrdEnv.SIMULATE)
 
-    def _safe_trade_call(self, method_name: str, **kwargs):
+    def _safe_trade_call(self, method_name: str, include_trd_env: bool = True, **kwargs):
         if self.trade_ctx is None or self.ft is None:
             raise RuntimeError("FutuConnector not connected")
         method = getattr(self.trade_ctx, method_name)
-        trd_env = self._resolved_trd_env()
 
         try:
-            ret, data = method(trd_env=trd_env, **kwargs)
+            if include_trd_env:
+                kwargs["trd_env"] = self._resolved_trd_env()
+            ret, data = method(**kwargs)
             if ret != self.ft.RET_OK:
                 raise RuntimeError(f"{method_name} failed: {data}")
             return data
@@ -125,7 +126,7 @@ class FutuConnector:
         Returns DataFrame with account metadata, including acc_id, account type and status.
         """
         try:
-            data = self._safe_trade_call("get_acc_list")
+            data = self._safe_trade_call("get_acc_list", include_trd_env=False)
             if data is None:
                 self.discovered_accounts = pd.DataFrame()
                 return self.discovered_accounts
@@ -179,27 +180,69 @@ class FutuConnector:
             self.logger.warning("Futu heartbeat failed: %s", exc)
             return False
 
-    def get_latest_quote(self, symbol: str) -> dict:
-        if self.quote_ctx is None or self.ft is None:
-            raise RuntimeError("FutuConnector not connected")
+    def _standard_quote_payload(self, row: dict[str, Any]) -> dict:
+        return {
+            "Date": pd.Timestamp.now(),
+            "Open": float(row.get("Open", row.get("Close", 0.0))),
+            "High": float(row.get("High", row.get("Close", 0.0))),
+            "Low": float(row.get("Low", row.get("Close", 0.0))),
+            "Close": float(row.get("Close", 0.0)),
+            "Volume": float(row.get("Volume", 0.0)),
+        }
 
+    def _get_latest_quote_yfinance(self, symbol: str) -> dict:
+        try:
+            import yfinance as yf
+        except Exception as exc:
+            raise RuntimeError(f"yfinance unavailable in current venv: {exc}") from exc
+
+        ticker = yf.Ticker(symbol)
+        hist = ticker.history(period="1d", interval="1m")
+        if hist is None or hist.empty:
+            hist = ticker.history(period="5d", interval="1d")
+        if hist is None or hist.empty:
+            raise RuntimeError(f"No yfinance price data returned for {symbol}")
+
+        last = hist.iloc[-1]
+        payload = self._standard_quote_payload(
+            {
+                "Open": last.get("Open", last.get("Close", 0.0)),
+                "High": last.get("High", last.get("Close", 0.0)),
+                "Low": last.get("Low", last.get("Close", 0.0)),
+                "Close": last.get("Close", 0.0),
+                "Volume": last.get("Volume", 0.0),
+            }
+        )
+        self.logger.warning("[YFINANCE] Fallback quote used for %s: close=%.4f", symbol, payload["Close"])
+        return payload
+
+    def get_latest_quote(self, symbol: str) -> dict:
         code = f"{self.config.market_prefix}.{symbol}"
+
+        if self.quote_ctx is None or self.ft is None:
+            self.logger.warning("[YFINANCE] Futu quote context unavailable for %s, using fallback", code)
+            return self._get_latest_quote_yfinance(symbol)
+
         try:
             ret, df = self.quote_ctx.get_stock_quote([code])
             if ret != self.ft.RET_OK or df.empty:
                 raise RuntimeError(f"Failed to fetch quote for {code}: {df}")
 
             row = df.iloc[0]
-            return {
-                "Date": pd.Timestamp.now(),
-                "Open": float(row.get("open_price", row.get("last_price", 0.0))),
-                "High": float(row.get("high_price", row.get("last_price", 0.0))),
-                "Low": float(row.get("low_price", row.get("last_price", 0.0))),
-                "Close": float(row.get("last_price", 0.0)),
-                "Volume": float(row.get("volume", 0.0)),
-            }
+            payload = self._standard_quote_payload(
+                {
+                    "Open": row.get("open_price", row.get("last_price", 0.0)),
+                    "High": row.get("high_price", row.get("last_price", 0.0)),
+                    "Low": row.get("low_price", row.get("last_price", 0.0)),
+                    "Close": row.get("last_price", 0.0),
+                    "Volume": row.get("volume", 0.0),
+                }
+            )
+            self.logger.info("[FUTU] Quote used for %s: close=%.4f", code, payload["Close"])
+            return payload
         except Exception as exc:
-            raise RuntimeError(f"Quote query failed for {code}: {exc}") from exc
+            self.logger.warning("[YFINANCE] Futu quote failed for %s: %s", code, exc)
+            return self._get_latest_quote_yfinance(symbol)
 
     def get_sync_assets(self) -> dict:
         data = self._safe_trade_call("accinfo_query", **self._account_kwargs())
@@ -219,7 +262,36 @@ class FutuConnector:
             return pd.DataFrame()
         return data.copy()
 
-    def place_order(self, symbol: str, qty: int, side: str, price: Optional[float] = None) -> object:
+    def _safe_best_price(self, symbol: str, side: str, fallback_price: Optional[float]) -> float:
+        code = f"{self.config.market_prefix}.{symbol}"
+        if self.quote_ctx is None or self.ft is None:
+            if fallback_price is not None:
+                return float(fallback_price)
+            raise RuntimeError(f"Quote context unavailable for simulated limit conversion: {code}")
+
+        ret, df = self.quote_ctx.get_stock_quote([code])
+        if ret != self.ft.RET_OK or df.empty:
+            if fallback_price is not None:
+                return float(fallback_price)
+            raise RuntimeError(f"Unable to fetch quote for simulated limit conversion: {code}")
+
+        row = df.iloc[0]
+        ask = float(row.get("ask_price", row.get("last_price", 0.0)) or 0.0)
+        bid = float(row.get("bid_price", row.get("last_price", 0.0)) or 0.0)
+        last = float(row.get("last_price", 0.0) or 0.0)
+
+        if side.upper() == "BUY":
+            return ask if ask > 0 else (last if last > 0 else float(fallback_price or 0.0))
+        return bid if bid > 0 else (last if last > 0 else float(fallback_price or 0.0))
+
+    def place_order(
+        self,
+        symbol: str,
+        qty: int,
+        side: str,
+        price: Optional[float] = None,
+        order_type: str = "MARKET",
+    ) -> object:
         if self.trade_ctx is None or self.ft is None:
             raise RuntimeError("FutuConnector not connected")
         if qty <= 0:
@@ -227,8 +299,23 @@ class FutuConnector:
 
         code = f"{self.config.market_prefix}.{symbol}"
         trd_side = self.ft.TrdSide.BUY if side.upper() == "BUY" else self.ft.TrdSide.SELL
-        order_type = self.ft.OrderType.NORMAL
-        order_price = 0 if price is None else float(price)
+        resolved_order_type = order_type.upper()
+        resolved_trd_env = self._resolved_trd_env()
+
+        # Futu simulated environment may reject market orders; convert to aggressive limit.
+        if resolved_trd_env == self.ft.TrdEnv.SIMULATE and resolved_order_type == "MARKET":
+            order_price = self._safe_best_price(symbol, side, price)
+            futu_order_type = self.ft.OrderType.NORMAL
+            self.logger.info(
+                "[SIMULATE] MARKET->LIMIT conversion for %s %s qty=%d using %.4f",
+                symbol,
+                side.upper(),
+                qty,
+                order_price,
+            )
+        else:
+            order_price = 0 if price is None else float(price)
+            futu_order_type = self.ft.OrderType.MARKET if resolved_order_type == "MARKET" else self.ft.OrderType.NORMAL
 
         try:
             ret, data = self.trade_ctx.place_order(
@@ -236,13 +323,20 @@ class FutuConnector:
                 qty=qty,
                 code=code,
                 trd_side=trd_side,
-                order_type=order_type,
-                trd_env=self._resolved_trd_env(),
+                order_type=futu_order_type,
+                trd_env=resolved_trd_env,
                 **self._account_kwargs(),
             )
             if ret != self.ft.RET_OK:
                 raise RuntimeError(f"Order placement failed: {data}")
-            self.logger.info("Order placed: %s %d %s (acc_id=%s)", side.upper(), qty, symbol, self.config.target_acc_id)
+            self.logger.info(
+                "Order placed: %s %d %s type=%s (acc_id=%s)",
+                side.upper(),
+                qty,
+                symbol,
+                resolved_order_type,
+                self.config.target_acc_id,
+            )
             return data
         except Exception as exc:
             raise RuntimeError(f"Order placement exception for {code}: {exc}") from exc

--- a/v3_pipeline/core/main_loop.py
+++ b/v3_pipeline/core/main_loop.py
@@ -1,8 +1,10 @@
+import asyncio
+import json
 import logging
 import sys
-import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
 
 import pandas as pd
@@ -10,7 +12,10 @@ import pandas as pd
 from notifier import send_tg_msg
 from v3_pipeline.core.futu_connector import FutuConnector
 from v3_pipeline.features.indicators import TechnicalIndicatorGenerator
+from v3_pipeline.features.stock_frame import StockFrame
 from v3_pipeline.models.manager import ModelManager
+from v3_pipeline.models.strategy_factory import StrategyFactory
+from v3_pipeline.models.strategy_base import StrategyBase
 from v3_pipeline.risk.manager import RiskController
 
 
@@ -32,11 +37,19 @@ def _build_stderr_logger(name: str) -> logging.Logger:
 
 @dataclass
 class LiveConfig:
-    symbol: str = "TSLA"
+    symbols: list[str] = field(default_factory=lambda: ["TSLA"])
     polling_seconds: int = 60
     prediction_threshold: float = 0.01
     auto_trade: bool = False
     paper_trading: bool = True
+    strategy_name: str = "kiro_lstm"
+
+
+@dataclass
+class SymbolState:
+    position_qty: int = 0
+    highest_price_since_entry: float = 0.0
+    warmup_count: int = 0
 
 
 class LiveTradingLoop:
@@ -49,60 +62,88 @@ class LiveTradingLoop:
         futu_connector: Optional[FutuConnector] = None,
         feature_generator: Optional[TechnicalIndicatorGenerator] = None,
         config: Optional[LiveConfig] = None,
+        config_json_path: str = "config.json",
     ) -> None:
         self.model_manager = model_manager
         self.risk_controller = risk_controller
         self.futu_connector = futu_connector or FutuConnector()
         self.feature_generator = feature_generator or TechnicalIndicatorGenerator()
-        self.config = config or LiveConfig()
+        self.config = config or self._load_runtime_config(config_json_path)
         self.logger = _build_stderr_logger(self.__class__.__name__)
 
-        self.market_buffer = pd.DataFrame(columns=["Date", "Open", "High", "Low", "Close", "Volume"])
+        self.stock_frame = StockFrame()
+        self.symbol_states: dict[str, SymbolState] = {s: SymbolState() for s in self.config.symbols}
+        self.strategy: StrategyBase = StrategyFactory.build(self.config.strategy_name, model_manager=self.model_manager)
+
         self.equity_peak = 0.0
         self.account_value = 100000.0
-        self.position_qty = 0
-        self.highest_price_since_entry = 0.0
+
+    def _load_runtime_config(self, config_json_path: str) -> LiveConfig:
+        cfg = LiveConfig()
+        p = Path(config_json_path)
+        if not p.exists():
+            return cfg
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+            section = data.get("v3", data) if isinstance(data, dict) else {}
+            symbols = section.get("symbols_list") or section.get("symbols")
+            if isinstance(symbols, list) and symbols:
+                cfg.symbols = [str(s).upper() for s in symbols]
+            cfg.polling_seconds = int(section.get("polling_seconds", cfg.polling_seconds))
+            cfg.prediction_threshold = float(section.get("prediction_threshold", cfg.prediction_threshold))
+            cfg.auto_trade = bool(section.get("auto_trade", cfg.auto_trade))
+            cfg.paper_trading = bool(section.get("paper_trading", cfg.paper_trading))
+            cfg.strategy_name = str(section.get("strategy", cfg.strategy_name))
+        except Exception as exc:
+            _build_stderr_logger(self.__class__.__name__).warning("Failed to parse %s: %s", config_json_path, exc)
+        return cfg
 
     def start(self) -> None:
         self.logger.info(
-            "Starting live loop symbol=%s auto_trade=%s paper_trading=%s",
-            self.config.symbol,
+            "Starting async live loop symbols=%s strategy=%s auto_trade=%s paper_trading=%s",
+            self.config.symbols,
+            self.config.strategy_name,
             self.config.auto_trade,
             self.config.paper_trading,
         )
         self.futu_connector.connect()
         try:
-            while True:
-                self.run_one_cycle()
-                time.sleep(self.config.polling_seconds)
+            asyncio.run(self._run_forever())
         finally:
             self.futu_connector.close()
 
-    def run_one_cycle(self) -> None:
+    async def _run_forever(self) -> None:
+        while True:
+            await self.run_one_cycle()
+            await asyncio.sleep(self.config.polling_seconds)
+
+    async def run_one_cycle(self) -> None:
         self._check_heartbeat()
         self._sync_broker_state()
+        await asyncio.gather(*(self._run_symbol_cycle(symbol) for symbol in self.config.symbols))
 
-        quote = self.futu_connector.get_latest_quote(self.config.symbol)
-        self.market_buffer = pd.concat([self.market_buffer, pd.DataFrame([quote])], ignore_index=True)
-        self.market_buffer["Date"] = pd.to_datetime(self.market_buffer["Date"], errors="coerce")
-        self.market_buffer = (
-            self.market_buffer.dropna(subset=["Date"])
-            .sort_values("Date")
-            .drop_duplicates(subset=["Date"], keep="last")
-            .reset_index(drop=True)
-        )
+    async def _run_symbol_cycle(self, symbol: str) -> None:
+        state = self.symbol_states.setdefault(symbol, SymbolState())
+        quote = await asyncio.to_thread(self.futu_connector.get_latest_quote, symbol)
+        self.stock_frame.append(symbol, quote)
 
-        featured = self.feature_generator.generate(self.market_buffer).dropna().reset_index(drop=True)
+        symbol_buffer = self.stock_frame.symbol_view(symbol)
+        featured = self.feature_generator.generate(symbol_buffer).dropna().reset_index(drop=True)
         if len(featured) <= self.model_manager.data_preparer.lookback:
-            self.logger.info("Warmup: waiting for more bars (%d/%d)", len(featured), self.model_manager.data_preparer.lookback)
+            state.warmup_count += 1
+            self.logger.info(
+                "Warmup[%s] count=%d bars=%d/%d",
+                symbol,
+                state.warmup_count,
+                len(featured),
+                self.model_manager.data_preparer.lookback,
+            )
             return
 
         current_price = float(featured.iloc[-1]["Close"])
-        prediction = self.model_manager.predict(featured)
+        prediction = float(await asyncio.to_thread(self.strategy.predict, featured))
 
-        # Use broker-synced values as baseline for risk/signals.
         self.equity_peak = max(self.equity_peak, self.account_value)
-
         if self.risk_controller.circuit_breaker_triggered(self.equity_peak, self.account_value):
             self._notify(f"🚨 Circuit breaker hit. Equity={self.account_value:.2f}")
             return
@@ -111,28 +152,27 @@ class LiveTradingLoop:
         threshold_up = current_price * (1 + self.config.prediction_threshold)
         threshold_down = current_price * (1 - self.config.prediction_threshold)
 
-        if self.position_qty > 0:
-            self.highest_price_since_entry = max(self.highest_price_since_entry, current_price)
-            if self.risk_controller.should_stop_out(current_price, self.highest_price_since_entry):
-                self._execute("SELL", self.position_qty, current_price, reason="trailing_stop")
+        if state.position_qty > 0:
+            state.highest_price_since_entry = max(state.highest_price_since_entry, current_price)
+            if self.risk_controller.should_stop_out(current_price, state.highest_price_since_entry):
+                self._execute(symbol, state, "SELL", state.position_qty, current_price, reason="trailing_stop")
                 action = "SELL"
 
         if action == "HOLD":
-            if prediction > threshold_up and self.position_qty == 0:
+            if prediction > threshold_up and state.position_qty == 0:
                 qty = self.risk_controller.calculate_position_size(self.account_value, current_price)
                 if qty > 0:
-                    self._execute("BUY", qty, current_price, reason="model_signal")
+                    self._execute(symbol, state, "BUY", qty, current_price, reason="model_signal")
                     action = "BUY"
-            elif prediction < threshold_down and self.position_qty > 0:
-                self._execute("SELL", self.position_qty, current_price, reason="model_signal")
+            elif prediction < threshold_down and state.position_qty > 0:
+                self._execute(symbol, state, "SELL", state.position_qty, current_price, reason="model_signal")
                 action = "SELL"
 
         self._notify(
-            f"💓 {datetime.utcnow().isoformat()} {self.config.symbol} "
+            f"💓 {datetime.utcnow().isoformat()} {symbol} "
             f"price={current_price:.4f} pred={prediction:.4f} action={action} "
-            f"equity={self.account_value:.2f} position={self.position_qty}"
+            f"equity={self.account_value:.2f} position={state.position_qty}"
         )
-
 
     def _check_heartbeat(self) -> None:
         try:
@@ -143,7 +183,7 @@ class LiveTradingLoop:
             self.logger.warning("Broker heartbeat check failed: %s", exc)
 
     def _sync_broker_state(self) -> None:
-        """Sync account value and symbol position from Futu; keep last known state on failure."""
+        """Sync account value and symbol positions from Futu; keep last known state on failure."""
         try:
             assets = self.futu_connector.get_sync_assets()
             synced_value = float(assets.get("total_assets", self.account_value))
@@ -155,43 +195,44 @@ class LiveTradingLoop:
 
         try:
             positions = self.futu_connector.get_sync_positions()
-            synced_qty = 0
-            if not positions.empty:
-                symbol_code = f"{self.futu_connector.config.market_prefix}.{self.config.symbol}"
-                if "code" in positions.columns:
-                    row = positions[positions["code"] == symbol_code]
-                elif "stock_name" in positions.columns:
-                    row = positions[positions["stock_name"] == self.config.symbol]
-                else:
-                    row = pd.DataFrame()
+            for symbol, state in self.symbol_states.items():
+                synced_qty = 0
+                if not positions.empty:
+                    symbol_code = f"{self.futu_connector.config.market_prefix}.{symbol}"
+                    if "code" in positions.columns:
+                        row = positions[positions["code"] == symbol_code]
+                    elif "stock_name" in positions.columns:
+                        row = positions[positions["stock_name"] == symbol]
+                    else:
+                        row = pd.DataFrame()
 
-                if not row.empty:
-                    qty_col = "qty" if "qty" in row.columns else "can_sell_qty" if "can_sell_qty" in row.columns else None
-                    if qty_col is not None:
-                        synced_qty = int(float(row.iloc[0][qty_col]))
+                    if not row.empty:
+                        qty_col = "qty" if "qty" in row.columns else "can_sell_qty" if "can_sell_qty" in row.columns else None
+                        if qty_col is not None:
+                            synced_qty = int(float(row.iloc[0][qty_col]))
 
-            self.position_qty = max(0, synced_qty)
-            if self.position_qty == 0:
-                self.highest_price_since_entry = 0.0
-            self.logger.info("Synced position qty for %s: %d", self.config.symbol, self.position_qty)
+                state.position_qty = max(0, synced_qty)
+                if state.position_qty == 0:
+                    state.highest_price_since_entry = 0.0
+                self.logger.info("Synced position qty for %s: %d", symbol, state.position_qty)
         except Exception as exc:
-            self.logger.warning("Position sync failed, using last known position %d: %s", self.position_qty, exc)
+            self.logger.warning("Position sync failed: %s", exc)
 
-    def _execute(self, side: str, qty: int, price: float, reason: str) -> None:
-        self.logger.info("Execute %s qty=%d price=%.4f reason=%s", side, qty, price, reason)
-
-        if side == "BUY":
-            self.position_qty += qty
-            self.highest_price_since_entry = price
-        elif side == "SELL":
-            self.position_qty = max(0, self.position_qty - qty)
-            if self.position_qty == 0:
-                self.highest_price_since_entry = 0.0
+    def _execute(self, symbol: str, state: SymbolState, side: str, qty: int, price: float, reason: str) -> None:
+        self.logger.info("Execute %s %s qty=%d price=%.4f reason=%s", symbol, side, qty, price, reason)
 
         if self.config.auto_trade and not self.config.paper_trading:
-            self.futu_connector.place_order(self.config.symbol, qty, side, price)
+            self.futu_connector.place_order(symbol, qty, side, price, order_type="MARKET")
         else:
-            self.logger.info("Paper trading mode: simulated %s %d %s", side, qty, self.config.symbol)
+            self.logger.info("Paper trading mode: simulated %s %d %s", side, qty, symbol)
+
+        if side == "BUY":
+            state.position_qty += qty
+            state.highest_price_since_entry = price
+        elif side == "SELL":
+            state.position_qty = max(0, state.position_qty - qty)
+            if state.position_qty == 0:
+                state.highest_price_since_entry = 0.0
 
     def _notify(self, message: str) -> None:
         self.logger.info(message)

--- a/v3_pipeline/features/stock_frame.py
+++ b/v3_pipeline/features/stock_frame.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+
+@dataclass
+class StockFrame:
+    """Multi-symbol OHLCV container with MultiIndex (symbol, Date)."""
+
+    frame: pd.DataFrame = field(default_factory=lambda: pd.DataFrame(columns=["symbol", "Date", "Open", "High", "Low", "Close", "Volume"]))
+
+    def append(self, symbol: str, quote: dict) -> None:
+        row = {
+            "symbol": symbol,
+            "Date": pd.to_datetime(quote.get("Date"), errors="coerce"),
+            "Open": quote.get("Open"),
+            "High": quote.get("High"),
+            "Low": quote.get("Low"),
+            "Close": quote.get("Close"),
+            "Volume": quote.get("Volume"),
+        }
+        incoming = pd.DataFrame([row]).dropna(subset=["Date"])
+        if incoming.empty:
+            return
+
+        self.frame = pd.concat([self.frame, incoming], ignore_index=True)
+        self.frame = self.frame.dropna(subset=["Date"]).drop_duplicates(subset=["symbol", "Date"], keep="last")
+        self.frame = self.frame.sort_values(["symbol", "Date"]).reset_index(drop=True)
+
+    def symbol_view(self, symbol: str) -> pd.DataFrame:
+        if self.frame.empty:
+            return pd.DataFrame(columns=["Date", "Open", "High", "Low", "Close", "Volume"])
+
+        indexed = self.frame.set_index(["symbol", "Date"]).sort_index()
+        try:
+            sub = indexed.xs(symbol, level="symbol").reset_index()
+        except KeyError:
+            return pd.DataFrame(columns=["Date", "Open", "High", "Low", "Close", "Volume"])
+        return sub[["Date", "Open", "High", "Low", "Close", "Volume"]]

--- a/v3_pipeline/models/strategy_base.py
+++ b/v3_pipeline/models/strategy_base.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import pandas as pd
+
+
+class StrategyBase(ABC):
+    """Pluggable strategy interface for multi-strategy prediction/execution."""
+
+    name: str = "base"
+
+    @abstractmethod
+    def predict(self, frame: pd.DataFrame) -> float:
+        """Return next-step target value or signal score."""
+
+    def fit(self, frame: pd.DataFrame) -> None:
+        """Optional training hook for strategies that require fitting."""
+        return None

--- a/v3_pipeline/models/strategy_factory.py
+++ b/v3_pipeline/models/strategy_factory.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from v3_pipeline.models.strategy_base import StrategyBase
+
+
+@dataclass
+class RulePlaceholderStrategy(StrategyBase):
+    """Placeholder for future RSI / breakout rule strategies."""
+
+    name: str = "rule_placeholder"
+
+    def predict(self, frame):  # type: ignore[override]
+        close = float(frame.iloc[-1]["Close"])
+        return close
+
+
+class StrategyFactory:
+    @staticmethod
+    def build(name: str, **kwargs: Any) -> StrategyBase:
+        strategy = name.lower()
+        if strategy == "kiro_lstm":
+            from v3_pipeline.models.manager import ModelManager
+            from v3_pipeline.models.strategy_plugins import KiroLSTMStrategy
+
+            manager = kwargs.get("model_manager")
+            if not isinstance(manager, ModelManager):
+                raise ValueError("kiro_lstm strategy requires model_manager=ModelManager")
+            return KiroLSTMStrategy(model_manager=manager)
+
+        if strategy in {"rsi_oversold", "volume_breakout"}:
+            # Reserved strategy hooks for future rule-based implementations.
+            return RulePlaceholderStrategy(name=strategy)
+
+        raise ValueError(f"Unknown strategy '{name}'")

--- a/v3_pipeline/models/strategy_plugins.py
+++ b/v3_pipeline/models/strategy_plugins.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from v3_pipeline.models.manager import ModelManager
+from v3_pipeline.models.strategy_base import StrategyBase
+
+
+@dataclass
+class KiroLSTMStrategy(StrategyBase):
+    """KiroLSTM plugin strategy wrapper."""
+
+    model_manager: ModelManager
+    name: str = "kiro_lstm"
+
+    def predict(self, frame: pd.DataFrame) -> float:
+        return float(self.model_manager.predict(frame))


### PR DESCRIPTION
### Motivation
- Provide a lightweight live log terminal for monitoring `v3_live_trade.log` over WebSocket. 
- Improve robustness of quote fetching and order placement in simulated environments. 
- Refactor the live trading loop to support multiple symbols, pluggable strategies, and async operation.

### Description
- Add a static UI `index.html` that connects to `/ws/v3_logs` and renders categorized log lines with auto-scroll. 
- Add `kiro_bridge.py` FastAPI app exposing `GET /`, `GET /health`, and `WebSocket /ws/v3_logs` to tail the configured log file, and add `scripts/start_kiro_bridge.sh` and updated `requirements.txt` (`fastapi`, `uvicorn`, `aiofiles`).
- Harden `v3_pipeline/core/futu_connector.py` by adding `_safe_trade_call(include_trd_env=...)`, yfinance fallback for quotes (`_get_latest_quote_yfinance`), a standard quote payload helper, `_safe_best_price` for simulated market->limit conversions, and change `place_order` to handle order type conversion and improved logging.
- Refactor live loop into async multi-symbol flow in `v3_pipeline/core/main_loop.py` with `LiveConfig` supporting `symbols` and `strategy_name`, runtime JSON config loader, `StockFrame` for multi-symbol OHLCV, per-symbol `SymbolState`, async cycle execution, strategy plugin integration, and updated position/account sync logic.
- Add strategy interface and plugins: `v3_pipeline/models/strategy_base.py`, `v3_pipeline/models/strategy_factory.py`, and `v3_pipeline/models/strategy_plugins.py` (includes `KiroLSTMStrategy` wrapper and placeholder rules).
- Add `v3_pipeline/features/stock_frame.py` as a multi-symbol OHLCV container with `append` and `symbol_view` helpers.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aed01c88e88328beca1fda904207a8)