### PR TITLE
Add Kiro Bridge log websocket UI, Futu connector robustness and async multi-symbol trading loop with strategy plugins

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kiro Bridge Tactical Terminal</title>
+  <style>
+    body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b0f14; color: #c9d1d9; }
+    .container { max-width: 1100px; margin: 24px auto; padding: 0 16px; }
+    .terminal { background: #0d1117; border: 1px solid #30363d; border-radius: 12px; padding: 16px; box-shadow: 0 0 40px rgba(56,139,253,.12); }
+    .header { display:flex; justify-content:space-between; align-items:center; margin-bottom:12px; }
+    .title { font-size: 20px; font-weight: 700; }
+    .subtitle { color:#8b949e; font-size: 13px; margin-top:4px; }
+    .toggle { display:flex; gap:8px; align-items:center; color:#8b949e; font-size:13px; }
+    .log-box { height: 60vh; overflow-y: auto; background:#010409; border: 1px solid #21262d; border-radius: 10px; padding: 10px; }
+    .line { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; margin: 0; }
+    .warning { color: #e3b341; }
+    .success { color: #3fb950; }
+    .danger { color: #f85149; }
+    .meta { color: #7d8590; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <section class="terminal">
+      <div class="header">
+        <div>
+          <div class="title">Tactical Terminal (戰術終端)</div>
+          <div class="subtitle" id="status">Connecting...</div>
+        </div>
+        <label class="toggle">
+          <input id="autoScroll" type="checkbox" checked />
+          Auto-Scroll (自動滾動)
+        </label>
+      </div>
+      <div id="logBox" class="log-box"></div>
+    </section>
+  </div>
+
+  <script>
+    const logBox = document.getElementById('logBox');
+    const statusEl = document.getElementById('status');
+    const autoScrollEl = document.getElementById('autoScroll');
+    let ws;
+    let reconnectMs = 1000;
+
+    const classify = (line) => {
+      if (line.includes('[ERROR]') || line.includes('Exception')) return 'danger';
+      if (line.includes('[TRADE]')) return 'success';
+      if (line.includes('[SIGNAL]')) return 'warning';
+      return 'meta';
+    };
+
+    const appendLine = (line) => {
+      if (!line || line.includes('[HEARTBEAT]')) return;
+      const row = document.createElement('p');
+      row.className = `line ${classify(line)}`;
+      row.textContent = line;
+      logBox.appendChild(row);
+
+      if (logBox.children.length > 2000) {
+        logBox.removeChild(logBox.firstChild);
+      }
+
+      if (autoScrollEl.checked) {
+        logBox.scrollTop = logBox.scrollHeight;
+      }
+    };
+
+    const wsUrl = () => {
+      const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+      return `${proto}://${location.host}/ws/v3_logs`;
+    };
+
+    const connect = () => {
+      ws = new WebSocket(wsUrl());
+      statusEl.textContent = 'Connecting to /ws/v3_logs...';
+
+      ws.onopen = () => {
+        statusEl.textContent = '✅ Live connected';
+        reconnectMs = 1000;
+      };
+
+      ws.onmessage = (event) => appendLine(event.data);
+
+      ws.onclose = () => {
+        statusEl.textContent = `⚠️ Disconnected, retry in ${Math.floor(reconnectMs/1000)}s`;
+        setTimeout(connect, reconnectMs);
+        reconnectMs = Math.min(reconnectMs * 2, 10000);
+      };
+
+      ws.onerror = () => ws.close();
+    };
+
+    connect();
+  </script>
+</body>
+</html>

--- a/kiro_bridge.py
+++ b/kiro_bridge.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import asyncio
+import os
+from collections import deque
+from pathlib import Path
+from typing import AsyncIterator
+
+import aiofiles
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import FileResponse, JSONResponse
+
+APP_HOST = os.getenv("KIRO_BRIDGE_HOST", "0.0.0.0")
+APP_PORT = int(os.getenv("KIRO_BRIDGE_PORT", "18888"))
+LOG_PATH = Path(
+    os.getenv(
+        "V3_LOG_PATH",
+        "/home/tsukii0607/.openclaw/workspace/skills/futu-api/v3_pipeline/logs/v3_live_trade.log",
+    )
+)
+
+app = FastAPI(title="Kiro Bridge", version="1.0.0")
+
+
+@app.get("/")
+async def index() -> FileResponse:
+    return FileResponse("index.html")
+
+
+@app.get("/health")
+async def health() -> JSONResponse:
+    return JSONResponse(
+        {
+            "ok": True,
+            "log_exists": LOG_PATH.exists(),
+            "log_path": str(LOG_PATH),
+        }
+    )
+
+
+def tail_lines(path: Path, max_lines: int = 120) -> list[str]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        return [line.rstrip("\n") for line in deque(handle, maxlen=max_lines)]
+
+
+async def follow_log(path: Path, poll_seconds: float = 0.4) -> AsyncIterator[str]:
+    while not path.exists():
+        await asyncio.sleep(poll_seconds)
+
+    stream = await aiofiles.open(path, "r", encoding="utf-8", errors="replace")
+    await stream.seek(0, os.SEEK_END)
+    last_inode = path.stat().st_ino
+
+    try:
+        while True:
+            line = await stream.readline()
+            if line:
+                yield line.rstrip("\n")
+                continue
+
+            yield ""
+            await asyncio.sleep(poll_seconds)
+
+            if path.exists() and path.stat().st_ino != last_inode:
+                await stream.close()
+                stream = await aiofiles.open(path, "r", encoding="utf-8", errors="replace")
+                last_inode = path.stat().st_ino
+    finally:
+        await stream.close()
+
+
+@app.websocket("/ws/v3_logs")
+async def ws_v3_logs(ws: WebSocket) -> None:
+    await ws.accept()
+    for line in tail_lines(LOG_PATH):
+        await ws.send_text(line)
+
+    try:
+        async for new_line in follow_log(LOG_PATH):
+            if new_line:
+                await ws.send_text(new_line)
+            else:
+                await ws.send_text("[HEARTBEAT] ws_alive")
+    except WebSocketDisconnect:
+        return
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("kiro_bridge:app", host=APP_HOST, port=APP_PORT, reload=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 futu-api>=9.0
 pandas>=1.0
+fastapi>=0.110
+uvicorn>=0.29
+aiofiles>=23.2

--- a/scripts/start_kiro_bridge.sh
+++ b/scripts/start_kiro_bridge.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+export KIRO_BRIDGE_HOST="${KIRO_BRIDGE_HOST:-0.0.0.0}"
+export KIRO_BRIDGE_PORT="${KIRO_BRIDGE_PORT:-18888}"
+export V3_LOG_PATH="${V3_LOG_PATH:-/home/tsukii0607/.openclaw/workspace/skills/futu-api/v3_pipeline/logs/v3_live_trade.log}"
+
+python -m uvicorn kiro_bridge:app --host "$KIRO_BRIDGE_HOST" --port "$KIRO_BRIDGE_PORT"

--- a/v3_pipeline/core/futu_connector.py
+++ b/v3_pipeline/core/futu_connector.py
@@ -31,15 +31,11 @@ class FutuConfig:
     port: int = int(os.getenv("FUTU_OPEND_PORT", "11111"))
     market_prefix: str = os.getenv("FUTU_MARKET_PREFIX", "US")
     trd_env: str = os.getenv("FUTU_TRD_ENV", "SIMULATE")
-    target_acc_id: Optional[int] = (
-        int(os.getenv("FUTU_TARGET_ACC_ID")) if os.getenv("FUTU_TARGET_ACC_ID") else None
-    )
+    target_acc_id: Optional[int] = int(os.getenv("FUTU_TARGET_ACC_ID")) if os.getenv("FUTU_TARGET_ACC_ID") else None
     opend_web_port: int = int(os.getenv("FUTU_OPEND_WEB_PORT", "18889"))
 
 
 class FutuConnector:
-    """Futu OpenAPI adapter for quotes, account sync, account discovery and order placement."""
-
     def __init__(self, config: Optional[FutuConfig] = None, config_json_path: str = "config.json") -> None:
         self.config = config or FutuConfig()
         self.logger = _build_stderr_logger(self.__class__.__name__)
@@ -53,7 +49,6 @@ class FutuConnector:
         self._load_runtime_config(config_json_path)
 
     def _load_runtime_config(self, config_json_path: str) -> None:
-        """Optional config.json override for target account selection."""
         try:
             p = Path(config_json_path)
             if not p.exists():
@@ -63,9 +58,8 @@ class FutuConnector:
             target = futu_section.get("target_acc_id")
             if target is not None and self.config.target_acc_id is None:
                 self.config.target_acc_id = int(target)
-                self.logger.info("Loaded target_acc_id from config.json: %s", self.config.target_acc_id)
         except Exception as exc:
-            self.logger.warning("Failed to parse config.json for futu settings: %s", exc)
+            self.logger.warning("Failed to parse config for futu settings: %s", exc)
 
     def connect(self) -> None:
         try:
@@ -74,13 +68,7 @@ class FutuConnector:
             self.ft = ft
             self.quote_ctx = ft.OpenQuoteContext(host=self.config.host, port=self.config.port)
             self.trade_ctx = ft.OpenUSTradeContext(host=self.config.host, port=self.config.port)
-            self.logger.info(
-                "Connected to Futu OpenD at %s:%s (trd_env=%s, web_port_expected=%s)",
-                self.config.host,
-                self.config.port,
-                self.config.trd_env,
-                self.config.opend_web_port,
-            )
+            self.logger.info("Connected to Futu OpenD at %s:%s (trd_env=%s)", self.config.host, self.config.port, self.config.trd_env)
             self.discover_accounts()
         except Exception as exc:
             self._safe_close_contexts()
@@ -88,7 +76,6 @@ class FutuConnector:
 
     def close(self) -> None:
         self._safe_close_contexts()
-        self.logger.info("Closed Futu contexts")
 
     def _safe_close_contexts(self) -> None:
         for ctx in [self.quote_ctx, self.trade_ctx]:
@@ -105,14 +92,15 @@ class FutuConnector:
             raise RuntimeError("Futu SDK not loaded. Call connect() first.")
         return getattr(self.ft.TrdEnv, self.config.trd_env, self.ft.TrdEnv.SIMULATE)
 
-    def _safe_trade_call(self, method_name: str, **kwargs):
+    def _safe_trade_call(self, method_name: str, include_trd_env: bool = True, **kwargs):
         if self.trade_ctx is None or self.ft is None:
             raise RuntimeError("FutuConnector not connected")
         method = getattr(self.trade_ctx, method_name)
-        trd_env = self._resolved_trd_env()
 
         try:
-            ret, data = method(trd_env=trd_env, **kwargs)
+            if include_trd_env:
+                kwargs["trd_env"] = self._resolved_trd_env()
+            ret, data = method(**kwargs)
             if ret != self.ft.RET_OK:
                 raise RuntimeError(f"{method_name} failed: {data}")
             return data
@@ -120,12 +108,8 @@ class FutuConnector:
             raise RuntimeError(f"Trade API call {method_name} failed: {exc}") from exc
 
     def discover_accounts(self) -> pd.DataFrame:
-        """Discover all trade accounts and log identity mapping details.
-
-        Returns DataFrame with account metadata, including acc_id, account type and status.
-        """
         try:
-            data = self._safe_trade_call("get_acc_list")
+            data = self._safe_trade_call("get_acc_list", include_trd_env=False)
             if data is None:
                 self.discovered_accounts = pd.DataFrame()
                 return self.discovered_accounts
@@ -137,26 +121,8 @@ class FutuConnector:
 
             self.discovered_accounts = discovered
 
-            if "login_id" in discovered.columns and not discovered.empty:
-                self.login_account = int(discovered.iloc[0].get("login_id")) if pd.notna(discovered.iloc[0].get("login_id")) else None
-
-            self.logger.info("Account discovery (login_account/Bull-ID=%s):", self.login_account)
-            for _, row in discovered.iterrows():
-                status = "ACTIVE" if bool(row.get("is_trd_enabled", True)) else "DISABLED"
-                self.logger.info(
-                    " - acc_id=%s, acc_type=%s, sim_acc_type=%s, trd_env=%s, status=%s",
-                    row.get("acc_id"),
-                    row.get("acc_type"),
-                    row.get("sim_acc_type"),
-                    row.get("trd_env"),
-                    status,
-                )
-
             if self.config.target_acc_id is None and "acc_id" in discovered.columns and not discovered.empty:
                 self.config.target_acc_id = int(discovered.iloc[0]["acc_id"])
-                self.logger.info("Auto-selected target_acc_id=%s", self.config.target_acc_id)
-            elif self.config.target_acc_id is not None:
-                self.logger.info("Configured target_acc_id=%s", self.config.target_acc_id)
 
             return self.discovered_accounts
         except Exception as exc:
@@ -165,41 +131,97 @@ class FutuConnector:
             return self.discovered_accounts
 
     def _account_kwargs(self) -> dict[str, Any]:
-        if self.config.target_acc_id is None:
-            return {}
-        return {"acc_id": int(self.config.target_acc_id)}
+        return {"acc_id": int(self.config.target_acc_id)} if self.config.target_acc_id is not None else {}
 
     def heartbeat(self) -> bool:
-        """Connection heartbeat: validates trade context authorization/activity."""
         try:
             _ = self._safe_trade_call("accinfo_query", **self._account_kwargs())
-            self.logger.info("Futu heartbeat OK (acc_id=%s)", self.config.target_acc_id)
             return True
         except Exception as exc:
             self.logger.warning("Futu heartbeat failed: %s", exc)
             return False
 
-    def get_latest_quote(self, symbol: str) -> dict:
-        if self.quote_ctx is None or self.ft is None:
-            raise RuntimeError("FutuConnector not connected")
+    def _standard_quote_payload(self, row: dict[str, Any]) -> dict:
+        return {
+            "Date": pd.Timestamp.now(),
+            "Open": float(row.get("Open", row.get("Close", 0.0))),
+            "High": float(row.get("High", row.get("Close", 0.0))),
+            "Low": float(row.get("Low", row.get("Close", 0.0))),
+            "Close": float(row.get("Close", 0.0)),
+            "Volume": float(row.get("Volume", 0.0)),
+        }
 
+    def _get_latest_quote_yfinance(self, symbol: str) -> dict:
+        try:
+            import yfinance as yf
+        except Exception as exc:
+            raise RuntimeError(f"yfinance unavailable in current venv: {exc}") from exc
+
+        ticker = yf.Ticker(symbol)
+        hist = ticker.history(period="1d", interval="1m")
+        if hist is None or hist.empty:
+            hist = ticker.history(period="5d", interval="1d")
+        if hist is None or hist.empty:
+            raise RuntimeError(f"No yfinance price data returned for {symbol}")
+
+        last = hist.iloc[-1]
+        payload = self._standard_quote_payload(
+            {
+                "Open": last.get("Open", last.get("Close", 0.0)),
+                "High": last.get("High", last.get("Close", 0.0)),
+                "Low": last.get("Low", last.get("Close", 0.0)),
+                "Close": last.get("Close", 0.0),
+                "Volume": last.get("Volume", 0.0),
+            }
+        )
+        self.logger.warning("[YFINANCE] Fallback quote used for %s: close=%.4f", symbol, payload["Close"])
+        return payload
+
+    def get_latest_quote(self, symbol: str) -> dict:
         code = f"{self.config.market_prefix}.{symbol}"
+
+        if self.quote_ctx is None or self.ft is None:
+            self.logger.warning("[YFINANCE] Futu quote context unavailable for %s, using fallback", code)
+            return self._get_latest_quote_yfinance(symbol)
+
         try:
             ret, df = self.quote_ctx.get_stock_quote([code])
             if ret != self.ft.RET_OK or df.empty:
                 raise RuntimeError(f"Failed to fetch quote for {code}: {df}")
 
             row = df.iloc[0]
-            return {
-                "Date": pd.Timestamp.now(),
-                "Open": float(row.get("open_price", row.get("last_price", 0.0))),
-                "High": float(row.get("high_price", row.get("last_price", 0.0))),
-                "Low": float(row.get("low_price", row.get("last_price", 0.0))),
-                "Close": float(row.get("last_price", 0.0)),
-                "Volume": float(row.get("volume", 0.0)),
-            }
+            payload = self._standard_quote_payload(
+                {
+                    "Open": row.get("open_price", row.get("last_price", 0.0)),
+                    "High": row.get("high_price", row.get("last_price", 0.0)),
+                    "Low": row.get("low_price", row.get("last_price", 0.0)),
+                    "Close": row.get("last_price", 0.0),
+                    "Volume": row.get("volume", 0.0),
+                }
+            )
+            self.logger.info("[FUTU] Quote used for %s: close=%.4f", code, payload["Close"])
+            return payload
         except Exception as exc:
-            raise RuntimeError(f"Quote query failed for {code}: {exc}") from exc
+            self.logger.warning("[YFINANCE] Futu quote failed for %s: %s", code, exc)
+            return self._get_latest_quote_yfinance(symbol)
+
+    def _derive_simulate_limit_price(self, symbol: str, side: str, fallback_price: float) -> float:
+        code = f"{self.config.market_prefix}.{symbol}"
+        if self.quote_ctx is None or self.ft is None:
+            return float(fallback_price)
+        try:
+            ret, data = self.quote_ctx.get_order_book(code, num=1)
+            if ret != self.ft.RET_OK or data is None:
+                return float(fallback_price)
+            bid_list = data.get("Bid", [])
+            ask_list = data.get("Ask", [])
+            if side.upper() == "BUY" and ask_list:
+                return float(ask_list[0][0])
+            if side.upper() == "SELL" and bid_list:
+                return float(bid_list[0][0])
+        except Exception:
+            pass
+        return float(fallback_price)
 
     def get_sync_assets(self) -> dict:
         data = self._safe_trade_call("accinfo_query", **self._account_kwargs())
@@ -219,7 +241,7 @@ class FutuConnector:
             return pd.DataFrame()
         return data.copy()
 
-    def place_order(self, symbol: str, qty: int, side: str, price: Optional[float] = None) -> object:
+    def place_order(self, symbol: str, qty: int, side: str, price: Optional[float] = None, order_kind: str = "LIMIT") -> object:
         if self.trade_ctx is None or self.ft is None:
             raise RuntimeError("FutuConnector not connected")
         if qty <= 0:
@@ -227,8 +249,24 @@ class FutuConnector:
 
         code = f"{self.config.market_prefix}.{symbol}"
         trd_side = self.ft.TrdSide.BUY if side.upper() == "BUY" else self.ft.TrdSide.SELL
-        order_type = self.ft.OrderType.NORMAL
-        order_price = 0 if price is None else float(price)
+        desired_kind = order_kind.upper()
+
+        trd_env = self._resolved_trd_env()
+        is_sim = trd_env == self.ft.TrdEnv.SIMULATE
+
+        # Simulation environments often reject market orders: force to executable limit.
+        if desired_kind == "MARKET" and is_sim:
+            quote = self.get_latest_quote(symbol)
+            limit_price = self._derive_simulate_limit_price(symbol, side, quote["Close"])
+            order_type = self.ft.OrderType.NORMAL
+            order_price = float(limit_price)
+            self.logger.info("[SIM_FIX] MARKET converted to LIMIT for %s %s @ %.4f", side.upper(), code, order_price)
+        elif desired_kind == "MARKET":
+            order_type = self.ft.OrderType.MARKET
+            order_price = 0
+        else:
+            order_type = self.ft.OrderType.NORMAL
+            order_price = float(price) if price is not None else float(self.get_latest_quote(symbol)["Close"])
 
         try:
             ret, data = self.trade_ctx.place_order(
@@ -237,7 +275,7 @@ class FutuConnector:
                 code=code,
                 trd_side=trd_side,
                 order_type=order_type,
-                trd_env=self._resolved_trd_env(),
+                trd_env=trd_env,
                 **self._account_kwargs(),
             )
             if ret != self.ft.RET_OK:

--- a/v3_pipeline/core/main_loop.py
+++ b/v3_pipeline/core/main_loop.py
@@ -1,8 +1,10 @@
+import asyncio
+import json
 import logging
 import sys
-import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
 
 import pandas as pd
@@ -32,16 +34,46 @@ def _build_stderr_logger(name: str) -> logging.Logger:
 
 @dataclass
 class LiveConfig:
-    symbol: str = "TSLA"
+    symbols_list: list[str] = field(default_factory=lambda: ["TSLA"])
     polling_seconds: int = 60
     prediction_threshold: float = 0.01
     auto_trade: bool = False
     paper_trading: bool = True
 
 
-class LiveTradingLoop:
-    """24/7-style live loop bridging real-time data -> features -> model -> execution."""
+@dataclass
+class SymbolState:
+    position_qty: int = 0
+    highest_price_since_entry: float = 0.0
+    warmup_count: int = 0
 
+
+class StockFrameLite:
+    """Minimal StockFrame-like multi-index buffer for multi-symbol OHLCV."""
+
+    def __init__(self) -> None:
+        self.frame = pd.DataFrame(columns=["Symbol", "Date", "Open", "High", "Low", "Close", "Volume"])
+
+    def append_quote(self, symbol: str, quote: dict) -> None:
+        row = dict(quote)
+        row["Symbol"] = symbol
+        self.frame = pd.concat([self.frame, pd.DataFrame([row])], ignore_index=True)
+        self.frame["Date"] = pd.to_datetime(self.frame["Date"], errors="coerce")
+        self.frame = (
+            self.frame.dropna(subset=["Date"])
+            .sort_values(["Symbol", "Date"])
+            .drop_duplicates(subset=["Symbol", "Date"], keep="last")
+            .reset_index(drop=True)
+        )
+
+    def get_symbol_frame(self, symbol: str) -> pd.DataFrame:
+        subset = self.frame[self.frame["Symbol"] == symbol].copy()
+        if subset.empty:
+            return pd.DataFrame(columns=["Date", "Open", "High", "Low", "Close", "Volume"])
+        return subset[["Date", "Open", "High", "Low", "Close", "Volume"]].reset_index(drop=True)
+
+
+class LiveTradingLoop:
     def __init__(
         self,
         model_manager: ModelManager,
@@ -49,60 +81,80 @@ class LiveTradingLoop:
         futu_connector: Optional[FutuConnector] = None,
         feature_generator: Optional[TechnicalIndicatorGenerator] = None,
         config: Optional[LiveConfig] = None,
+        config_json_path: str = "config.json",
     ) -> None:
         self.model_manager = model_manager
         self.risk_controller = risk_controller
-        self.futu_connector = futu_connector or FutuConnector()
+        self.futu_connector = futu_connector or FutuConnector(config_json_path=config_json_path)
         self.feature_generator = feature_generator or TechnicalIndicatorGenerator()
-        self.config = config or LiveConfig()
+        self.config = config or self._load_runtime_config(config_json_path)
         self.logger = _build_stderr_logger(self.__class__.__name__)
 
-        self.market_buffer = pd.DataFrame(columns=["Date", "Open", "High", "Low", "Close", "Volume"])
+        self.symbol_states: dict[str, SymbolState] = {s: SymbolState() for s in self.config.symbols_list}
+        self.stock_frame = StockFrameLite()
         self.equity_peak = 0.0
         self.account_value = 100000.0
-        self.position_qty = 0
-        self.highest_price_since_entry = 0.0
+
+    def _load_runtime_config(self, config_json_path: str) -> LiveConfig:
+        cfg = LiveConfig()
+        p = Path(config_json_path)
+        if not p.exists():
+            return cfg
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+            symbols = data.get("symbols_list") or data.get("symbols")
+            if isinstance(symbols, list) and symbols:
+                cfg.symbols_list = [str(s).upper() for s in symbols]
+
+            cfg.polling_seconds = int(data.get("polling_seconds", cfg.polling_seconds))
+            cfg.prediction_threshold = float(data.get("prediction_threshold", cfg.prediction_threshold))
+            cfg.auto_trade = bool(data.get("auto_trade", cfg.auto_trade))
+            cfg.paper_trading = bool(data.get("paper_trading", cfg.paper_trading))
+        except Exception as exc:
+            _build_stderr_logger(self.__class__.__name__).warning("Failed to parse %s: %s", config_json_path, exc)
+        return cfg
 
     def start(self) -> None:
-        self.logger.info(
-            "Starting live loop symbol=%s auto_trade=%s paper_trading=%s",
-            self.config.symbol,
-            self.config.auto_trade,
-            self.config.paper_trading,
-        )
+        self.logger.info("Starting async multi-symbol loop symbols=%s", self.config.symbols_list)
         self.futu_connector.connect()
         try:
-            while True:
-                self.run_one_cycle()
-                time.sleep(self.config.polling_seconds)
+            asyncio.run(self._run_forever())
         finally:
             self.futu_connector.close()
 
-    def run_one_cycle(self) -> None:
+    async def _run_forever(self) -> None:
+        while True:
+            await self.run_one_cycle()
+            await asyncio.sleep(self.config.polling_seconds)
+
+    async def run_one_cycle(self) -> None:
         self._check_heartbeat()
         self._sync_broker_state()
+        await asyncio.gather(*(self._run_symbol_cycle(symbol) for symbol in self.config.symbols_list))
 
-        quote = self.futu_connector.get_latest_quote(self.config.symbol)
-        self.market_buffer = pd.concat([self.market_buffer, pd.DataFrame([quote])], ignore_index=True)
-        self.market_buffer["Date"] = pd.to_datetime(self.market_buffer["Date"], errors="coerce")
-        self.market_buffer = (
-            self.market_buffer.dropna(subset=["Date"])
-            .sort_values("Date")
-            .drop_duplicates(subset=["Date"], keep="last")
-            .reset_index(drop=True)
-        )
+    async def _run_symbol_cycle(self, symbol: str) -> None:
+        state = self.symbol_states.setdefault(symbol, SymbolState())
 
-        featured = self.feature_generator.generate(self.market_buffer).dropna().reset_index(drop=True)
-        if len(featured) <= self.model_manager.data_preparer.lookback:
-            self.logger.info("Warmup: waiting for more bars (%d/%d)", len(featured), self.model_manager.data_preparer.lookback)
+        quote = await asyncio.to_thread(self.futu_connector.get_latest_quote, symbol)
+        self.stock_frame.append_quote(symbol, quote)
+
+        symbol_frame = self.stock_frame.get_symbol_frame(symbol)
+        featured = self.feature_generator.generate(symbol_frame).dropna().reset_index(drop=True)
+        state.warmup_count = len(featured)
+
+        if state.warmup_count <= self.model_manager.data_preparer.lookback:
+            self.logger.info(
+                "Warmup[%s]: waiting for more bars (%d/%d)",
+                symbol,
+                state.warmup_count,
+                self.model_manager.data_preparer.lookback,
+            )
             return
 
         current_price = float(featured.iloc[-1]["Close"])
-        prediction = self.model_manager.predict(featured)
+        prediction = float(await asyncio.to_thread(self.model_manager.predict, featured))
 
-        # Use broker-synced values as baseline for risk/signals.
         self.equity_peak = max(self.equity_peak, self.account_value)
-
         if self.risk_controller.circuit_breaker_triggered(self.equity_peak, self.account_value):
             self._notify(f"🚨 Circuit breaker hit. Equity={self.account_value:.2f}")
             return
@@ -111,28 +163,27 @@ class LiveTradingLoop:
         threshold_up = current_price * (1 + self.config.prediction_threshold)
         threshold_down = current_price * (1 - self.config.prediction_threshold)
 
-        if self.position_qty > 0:
-            self.highest_price_since_entry = max(self.highest_price_since_entry, current_price)
-            if self.risk_controller.should_stop_out(current_price, self.highest_price_since_entry):
-                self._execute("SELL", self.position_qty, current_price, reason="trailing_stop")
+        if state.position_qty > 0:
+            state.highest_price_since_entry = max(state.highest_price_since_entry, current_price)
+            if self.risk_controller.should_stop_out(current_price, state.highest_price_since_entry):
+                self._execute(symbol, state, "SELL", state.position_qty, current_price, reason="trailing_stop")
                 action = "SELL"
 
         if action == "HOLD":
-            if prediction > threshold_up and self.position_qty == 0:
+            if prediction > threshold_up and state.position_qty == 0:
                 qty = self.risk_controller.calculate_position_size(self.account_value, current_price)
                 if qty > 0:
-                    self._execute("BUY", qty, current_price, reason="model_signal")
+                    self._execute(symbol, state, "BUY", qty, current_price, reason="model_signal")
                     action = "BUY"
-            elif prediction < threshold_down and self.position_qty > 0:
-                self._execute("SELL", self.position_qty, current_price, reason="model_signal")
+            elif prediction < threshold_down and state.position_qty > 0:
+                self._execute(symbol, state, "SELL", state.position_qty, current_price, reason="model_signal")
                 action = "SELL"
 
         self._notify(
-            f"💓 {datetime.utcnow().isoformat()} {self.config.symbol} "
+            f"💓 {datetime.utcnow().isoformat()} {symbol} "
             f"price={current_price:.4f} pred={prediction:.4f} action={action} "
-            f"equity={self.account_value:.2f} position={self.position_qty}"
+            f"equity={self.account_value:.2f} position={state.position_qty} warmup={state.warmup_count}"
         )
-
 
     def _check_heartbeat(self) -> None:
         try:
@@ -143,55 +194,47 @@ class LiveTradingLoop:
             self.logger.warning("Broker heartbeat check failed: %s", exc)
 
     def _sync_broker_state(self) -> None:
-        """Sync account value and symbol position from Futu; keep last known state on failure."""
         try:
             assets = self.futu_connector.get_sync_assets()
             synced_value = float(assets.get("total_assets", self.account_value))
             if synced_value > 0:
                 self.account_value = synced_value
-                self.logger.info("Synced account value: %.2f", self.account_value)
         except Exception as exc:
             self.logger.warning("Asset sync failed, using last known account value %.2f: %s", self.account_value, exc)
 
         try:
             positions = self.futu_connector.get_sync_positions()
-            synced_qty = 0
-            if not positions.empty:
-                symbol_code = f"{self.futu_connector.config.market_prefix}.{self.config.symbol}"
-                if "code" in positions.columns:
-                    row = positions[positions["code"] == symbol_code]
-                elif "stock_name" in positions.columns:
-                    row = positions[positions["stock_name"] == self.config.symbol]
-                else:
-                    row = pd.DataFrame()
-
-                if not row.empty:
-                    qty_col = "qty" if "qty" in row.columns else "can_sell_qty" if "can_sell_qty" in row.columns else None
-                    if qty_col is not None:
-                        synced_qty = int(float(row.iloc[0][qty_col]))
-
-            self.position_qty = max(0, synced_qty)
-            if self.position_qty == 0:
-                self.highest_price_since_entry = 0.0
-            self.logger.info("Synced position qty for %s: %d", self.config.symbol, self.position_qty)
+            for symbol, state in self.symbol_states.items():
+                synced_qty = 0
+                if not positions.empty:
+                    symbol_code = f"{self.futu_connector.config.market_prefix}.{symbol}"
+                    row = positions[positions["code"] == symbol_code] if "code" in positions.columns else pd.DataFrame()
+                    if row.empty and "stock_name" in positions.columns:
+                        row = positions[positions["stock_name"] == symbol]
+                    if not row.empty:
+                        qty_col = "qty" if "qty" in row.columns else "can_sell_qty" if "can_sell_qty" in row.columns else None
+                        if qty_col is not None:
+                            synced_qty = int(float(row.iloc[0][qty_col]))
+                state.position_qty = max(0, synced_qty)
+                if state.position_qty == 0:
+                    state.highest_price_since_entry = 0.0
         except Exception as exc:
-            self.logger.warning("Position sync failed, using last known position %d: %s", self.position_qty, exc)
+            self.logger.warning("Position sync failed: %s", exc)
 
-    def _execute(self, side: str, qty: int, price: float, reason: str) -> None:
-        self.logger.info("Execute %s qty=%d price=%.4f reason=%s", side, qty, price, reason)
+    def _execute(self, symbol: str, state: SymbolState, side: str, qty: int, price: float, reason: str) -> None:
+        self.logger.info("Execute %s %s qty=%d price=%.4f reason=%s", symbol, side, qty, price, reason)
+        if self.config.auto_trade and not self.config.paper_trading:
+            self.futu_connector.place_order(symbol, qty, side, price, order_kind="MARKET")
+        else:
+            self.logger.info("Paper trading mode: simulated %s %d %s", side, qty, symbol)
 
         if side == "BUY":
-            self.position_qty += qty
-            self.highest_price_since_entry = price
+            state.position_qty += qty
+            state.highest_price_since_entry = price
         elif side == "SELL":
-            self.position_qty = max(0, self.position_qty - qty)
-            if self.position_qty == 0:
-                self.highest_price_since_entry = 0.0
-
-        if self.config.auto_trade and not self.config.paper_trading:
-            self.futu_connector.place_order(self.config.symbol, qty, side, price)
-        else:
-            self.logger.info("Paper trading mode: simulated %s %d %s", side, qty, self.config.symbol)
+            state.position_qty = max(0, state.position_qty - qty)
+            if state.position_qty == 0:
+                state.highest_price_since_entry = 0.0
 
     def _notify(self, message: str) -> None:
         self.logger.info(message)

--- a/v3_pipeline/models/manager.py
+++ b/v3_pipeline/models/manager.py
@@ -13,6 +13,8 @@ from torch.utils.data import DataLoader, TensorDataset
 from v3_pipeline.data.downloader import HistoricalDataDownloader
 from v3_pipeline.features.indicators import TechnicalIndicatorGenerator
 from v3_pipeline.models.brain import KiroLSTM
+from v3_pipeline.models.strategy_base import StrategyBase
+from v3_pipeline.models.strategy_factory import StrategyFactory
 
 REQUIRED_COLUMNS = ["Date", "Open", "High", "Low", "Close", "Volume"]
 
@@ -162,11 +164,13 @@ class ModelManager:
         data_preparer: DataPreparer,
         device: Optional[str] = None,
         model_dir: str = "v3_pipeline/models/trained_models",
+        strategy: Optional[StrategyBase] = None,
     ) -> None:
         self.logger = _build_stderr_logger(self.__class__.__name__)
         self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
         self.model = model.to(self.device)
         self.data_preparer = data_preparer
+        self.strategy = strategy or StrategyFactory.create("kiro_lstm")
         self.model_dir = Path(model_dir)
         self.model_dir.mkdir(parents=True, exist_ok=True)
 
@@ -208,13 +212,7 @@ class ModelManager:
         return losses
 
     def predict(self, latest_data_window: pd.DataFrame) -> float:
-        self.model.eval()
-        with torch.no_grad():
-            x = self.data_preparer.transform_for_inference(latest_data_window).to(self.device)
-            scaled_pred = float(self.model(x).cpu().numpy().ravel()[0])
-            pred = self.data_preparer.inverse_scale_target(scaled_pred)
-            self.logger.info("Prediction (scaled=%.6f, inverse=%.6f)", scaled_pred, pred)
-            return pred
+        return float(self.strategy.predict(self, latest_data_window))
 
     def save(self, model_name: str) -> Path:
         target = self.model_dir / f"{model_name}.pth"
@@ -227,6 +225,7 @@ class ModelManager:
             "feature_maxs": self.data_preparer.feature_maxs.to_dict() if self.data_preparer.feature_maxs is not None else None,
             "target_min": self.data_preparer.target_min,
             "target_max": self.data_preparer.target_max,
+            "strategy_name": getattr(self.strategy, "name", "kiro_lstm"),
         }
         torch.save(payload, target)
         self.logger.info("Saved model checkpoint to %s", target)
@@ -253,6 +252,7 @@ class ModelManager:
 
         self.data_preparer.target_min = payload.get("target_min")
         self.data_preparer.target_max = payload.get("target_max")
+        self.strategy = StrategyFactory.create(str(payload.get("strategy_name", "kiro_lstm")))
 
         self.model.eval()
         self.logger.info("Loaded model checkpoint from %s", source)

--- a/v3_pipeline/models/strategies.py
+++ b/v3_pipeline/models/strategies.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pandas as pd
+import torch
+
+from v3_pipeline.models.strategy_base import StrategyBase
+
+
+class KiroLSTMStrategy(StrategyBase):
+    name = "kiro_lstm"
+
+    def predict(self, manager: object, latest_data_window: pd.DataFrame) -> float:
+        manager.model.eval()
+        with torch.no_grad():
+            x = manager.data_preparer.transform_for_inference(latest_data_window).to(manager.device)
+            scaled_pred = float(manager.model(x).cpu().numpy().ravel()[0])
+            pred = manager.data_preparer.inverse_scale_target(scaled_pred)
+            manager.logger.info("[%s] Prediction (scaled=%.6f, inverse=%.6f)", self.name, scaled_pred, pred)
+            return pred
+
+
+class RSIOversoldStrategy(StrategyBase):
+    """Reserved plugin strategy scaffold for future RSI oversold logic."""
+
+    name = "rsi_oversold"
+
+    def predict(self, manager: object, latest_data_window: pd.DataFrame) -> float:
+        close = float(latest_data_window.iloc[-1]["Close"])
+        manager.logger.info("[%s] Placeholder strategy returning close=%.4f", self.name, close)
+        return close
+
+
+class VolumeBreakoutStrategy(StrategyBase):
+    """Reserved plugin strategy scaffold for future volume breakout logic."""
+
+    name = "volume_breakout"
+
+    def predict(self, manager: object, latest_data_window: pd.DataFrame) -> float:
+        close = float(latest_data_window.iloc[-1]["Close"])
+        manager.logger.info("[%s] Placeholder strategy returning close=%.4f", self.name, close)
+        return close

--- a/v3_pipeline/models/strategy_base.py
+++ b/v3_pipeline/models/strategy_base.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import pandas as pd
+
+
+class StrategyBase(ABC):
+    """Pluggable strategy interface for model-based and rule-based predictors."""
+
+    name: str = "base"
+
+    @abstractmethod
+    def predict(self, manager: object, latest_data_window: pd.DataFrame) -> float:
+        """Return target price/score prediction for the latest window."""
+        raise NotImplementedError

--- a/v3_pipeline/models/strategy_factory.py
+++ b/v3_pipeline/models/strategy_factory.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from v3_pipeline.models.strategies import KiroLSTMStrategy, RSIOversoldStrategy, VolumeBreakoutStrategy
+
+
+class StrategyFactory:
+    _registry = {
+        "kiro_lstm": KiroLSTMStrategy,
+        "rsi_oversold": RSIOversoldStrategy,
+        "volume_breakout": VolumeBreakoutStrategy,
+    }
+
+    @classmethod
+    def create(cls, name: str):
+        key = (name or "kiro_lstm").strip().lower()
+        if key not in cls._registry:
+            raise ValueError(f"Unknown strategy '{name}'. Available: {sorted(cls._registry.keys())}")
+        return cls._registry[key]()


### PR DESCRIPTION
### Motivation

- Provide a lightweight live log terminal served over WebSocket for real-time monitoring of v3 pipeline logs using a small web UI and bridge service.
- Harden Futu integration with better config parsing, fallbacks and simulation-friendly order handling to reduce runtime failures when the SDK or data is unavailable.
- Evolve the live trading loop to support multiple symbols, async execution and pluggable strategy implementations for easier experimentation and deployment.

### Description

- Add a simple web UI `index.html` and a FastAPI bridge `kiro_bridge.py` that tails a configured log file and exposes a WebSocket at `/ws/v3_logs`, and include a `scripts/start_kiro_bridge.sh` helper to run the service.
- Update `requirements.txt` to include `fastapi`, `uvicorn`, and `aiofiles` required by the bridge.
- Refactor `v3_pipeline/core/futu_connector.py` to improve logging and config handling, add a yfinance fallback for quotes (`_get_latest_quote_yfinance`), standardize quote payloads, derive executable limit prices for simulated market orders, and make trade calls optionally include `trd_env` to support different Futu API signatures.
- Rework `v3_pipeline/core/main_loop.py` to an async, multi-symbol `LiveTradingLoop` with `StockFrameLite` and `SymbolState` for per-symbol state, asynchronous fetching/prediction, and safer broker sync/execute logic.
- Introduce a pluggable strategy system by adding `v3_pipeline/models/strategy_base.py`, `strategy_factory.py`, and `strategies.py`, and wire strategy selection into `v3_pipeline/models/manager.py` so `ModelManager` delegates prediction to a strategy and persists `strategy_name` in checkpoints.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aed01c88e88328beca1fda904207a8)