### PR TITLE
Add WSL2 FutuOpenD connectivity hints and deployment runbook

### DIFF
--- a/FUTU_OPERATIONS.md
+++ b/FUTU_OPERATIONS.md
@@ -88,5 +88,22 @@ On heartbeat/sync failure:
 - **Port conflict on web UI**: ensure OpenD web port is `18889`; free `18888` for Kiro bridge.
 - **Frequent disconnects in WSL2**: verify `FUTU_OPEND_HOST`, firewall, and OpenD process health.
 
+## 9) WSL2 Deployment Notes (Windows host + Linux runtime)
+When FutuOpenD runs on Windows and strategy runs in WSL2:
+- WSL2 `127.0.0.1` is the Linux VM loopback, **not** Windows loopback.
+- If FutuOpenD only listens on `127.0.0.1`, WSL2 cannot connect directly.
+
+Recommended options:
+1. **Port forwarding on Windows (recommended)**
+   - Run in elevated PowerShell:
+   - `netsh interface portproxy add v4tov4 listenport=11111 listenaddress=0.0.0.0 connectport=11111 connectaddress=127.0.0.1`
+2. **Change FutuOpenD bind address**
+   - Configure FutuOpenD to listen on `0.0.0.0` instead of `127.0.0.1`.
+
+Deployment checklist:
+- Confirm FutuOpenD is running on Windows host and account is logged in.
+- For WSL2, configure Windows `portproxy` (or OpenD `0.0.0.0`).
+- Set `.env` / runtime env `FUTU_OPEND_HOST=<Windows host IP>` (for example `192.168.x.x`).
+
 ---
 This document is the canonical operational baseline for Kiro Quant V3 Futu integration.

--- a/tests/test_futu_connector_unlock.py
+++ b/tests/test_futu_connector_unlock.py
@@ -116,3 +116,49 @@ def test_connect_does_not_unlock_in_simulate_mode(monkeypatch):
 
     assert connector.trade_ctx is not None
     assert connector.trade_ctx.unlock_calls == []
+
+
+def test_connect_error_in_wsl2_includes_network_hints(monkeypatch):
+    cfg = FutuConfig(host="127.0.0.1", port=11111)
+    connector = FutuConnector(config=cfg)
+
+    class FailingFT:
+        RET_OK = 0
+
+        class TrdEnv:
+            REAL = "REAL"
+            SIMULATE = "SIMULATE"
+
+        class TrdSide:
+            BUY = "BUY"
+            SELL = "SELL"
+
+        class OrderType:
+            NORMAL = "NORMAL"
+
+        @staticmethod
+        def OpenQuoteContext(host, port):
+            raise ConnectionError("dial tcp 127.0.0.1:11111: connect: connection refused")
+
+        @staticmethod
+        def OpenUSTradeContext(host, port):
+            return DummyTradeContext()
+
+    monkeypatch.setattr(FutuConnector, "_is_wsl2", lambda self: True)
+    fake_module = types.SimpleNamespace(
+        RET_OK=FailingFT.RET_OK,
+        TrdEnv=FailingFT.TrdEnv,
+        TrdSide=FailingFT.TrdSide,
+        OrderType=FailingFT.OrderType,
+        OpenQuoteContext=FailingFT.OpenQuoteContext,
+        OpenUSTradeContext=FailingFT.OpenUSTradeContext,
+    )
+    monkeypatch.setitem(__import__("sys").modules, "futu", fake_module)
+
+    with pytest.raises(RuntimeError, match="WSL2 network hint") as exc_info:
+        connector.connect()
+
+    msg = str(exc_info.value)
+    assert "netsh interface portproxy add v4tov4" in msg
+    assert "Configure FutuOpenD to listen on 0.0.0.0" in msg
+    assert "FUTU_OPEND_HOST" in msg

--- a/v3_pipeline/core/futu_connector.py
+++ b/v3_pipeline/core/futu_connector.py
@@ -177,7 +177,31 @@ class FutuConnector:
                 self.unlock_trading(self.config.trade_password)
         except Exception as exc:
             self._safe_close_contexts()
-            raise RuntimeError(f"Failed to connect to Futu OpenD: {exc}") from exc
+            raise RuntimeError(self._build_connect_error(exc)) from exc
+
+    def _is_wsl2(self) -> bool:
+        if os.getenv("WSL_DISTRO_NAME"):
+            return True
+        try:
+            return "microsoft" in Path("/proc/version").read_text(encoding="utf-8").lower()
+        except Exception:
+            return False
+
+    def _build_connect_error(self, exc: Exception) -> str:
+        base_msg = f"Failed to connect to Futu OpenD: {exc}"
+        if not self._is_wsl2():
+            return base_msg
+
+        hint = (
+            "\nWSL2 network hint: localhost in WSL2 cannot directly access Windows 127.0.0.1 when "
+            "FutuOpenD only listens on loopback. Try either:\n"
+            "1) Windows portproxy (Admin PowerShell):\n"
+            "   netsh interface portproxy add v4tov4 listenport=11111 listenaddress=0.0.0.0 "
+            "connectport=11111 connectaddress=127.0.0.1\n"
+            "2) Configure FutuOpenD to listen on 0.0.0.0\n"
+            "3) Set FUTU_OPEND_HOST to Windows host IP in WSL2 (for example 192.168.x.x)."
+        )
+        return f"{base_msg}{hint}"
 
     def close(self) -> None:
         self._safe_close_contexts()


### PR DESCRIPTION
### Motivation
- WSL2 environments can’t directly reach Windows `127.0.0.1:11111` when FutuOpenD is bound to loopback, causing confusing connection failures; this change aims to make failures actionable and document remediation steps for deployments.

### Description
- Enrich `FutuConnector.connect()` error handling to call a new `_build_connect_error(...)` so connection exceptions include WSL2-specific troubleshooting hints instead of a bare error string.
- Add `_is_wsl2()` detection helper and `_build_connect_error()` which appends actionable guidance (Windows `netsh interface portproxy` command, alternative `0.0.0.0` bind, and `FUTU_OPEND_HOST` suggestion) when running under WSL2.
- Update `FUTU_OPERATIONS.md` with a new `WSL2 Deployment Notes` section describing the root cause, recommended fixes, and a deployment checklist for Windows-host + WSL2 runtimes.
- Add `test_connect_error_in_wsl2_includes_network_hints` to `tests/test_futu_connector_unlock.py` to assert the WSL2 hint text is present on connection failure.

### Testing
- Ran `pytest -q tests/test_futu_connector_unlock.py` and the suite passed (`5 passed`).
- Ran `python -m compileall v3_pipeline/core/futu_connector.py FUTU_OPERATIONS.md` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2889f32f8832184d7ea16101b89bd)