### PR TITLE
Fix #24/#25: runtime net-assets risk sizing & state timestamp sanitization

### DIFF
--- a/execution_engine.py
+++ b/execution_engine.py
@@ -146,6 +146,7 @@ class ExecutionEngine:
         # 1. 查賬戶資金
         acct = self.get_account_info()
         available_cash = acct.get("cash", 0)
+        total_assets = float(acct.get("total_assets", 0) or 0)
         
         # 實盤且資金過低（例如 < $1000）時警告
         if TRADE_MODE == "LIVE" and available_cash < 1000:
@@ -186,6 +187,7 @@ class ExecutionEngine:
             price=price,
             available_cash=available_cash,
             current_positions=positions,
+            net_assets=total_assets,
         )
 
         if not risk_result.get("ok"):

--- a/risk_guard.py
+++ b/risk_guard.py
@@ -29,6 +29,7 @@ class RiskGuard:
         price: float,
         available_cash: float,
         current_positions: dict,
+        net_assets: float | None = None,
     ) -> dict:
         """
         全面風控檢查
@@ -45,7 +46,9 @@ class RiskGuard:
 
         # ─── 3. 每日虧損上限 ───────────────────────────────────
         daily_pnl = ss.get_daily_pnl(state)
-        net = NET_ASSETS
+        net = float(net_assets or 0) if net_assets is not None else float(NET_ASSETS)
+        if net <= 0:
+            net = float(NET_ASSETS)
         loss_ratio = daily_pnl / net
         if loss_ratio < -self.cfg.max_daily_loss_pct:
             log.warning(

--- a/state_store.py
+++ b/state_store.py
@@ -32,6 +32,29 @@ def _default_state() -> dict:
     }
 
 
+def _sanitize_last_order_timestamps(state: dict):
+    """修正異常時間戳，避免未來時間導致冷卻/去重邏輯失真。"""
+    now = time.time()
+    last_orders = state.get("last_orders", {})
+    if not isinstance(last_orders, dict):
+        return
+
+    changed = False
+    for item in last_orders.values():
+        if not isinstance(item, dict):
+            continue
+        ts = item.get("time")
+        if not isinstance(ts, (int, float)):
+            continue
+        # 超過現在 5 分鐘視為異常未來時間
+        if ts > now + 300:
+            item["time"] = now
+            changed = True
+
+    if changed:
+        log.warning("⚠️ 偵測到未來時間戳，已自動修正 last_orders.time")
+
+
 def load() -> dict:
     try:
         with open(STATE_PATH, "r") as f:
@@ -41,6 +64,8 @@ def load() -> dict:
         s = _default_state()
         if isinstance(loaded, dict):
             s.update(loaded)
+
+        _sanitize_last_order_timestamps(s)
 
         # 如果日期不同（新的一天）→ 重置每日狀態
         if s.get("date") != str(date.today()):

--- a/tests/test_risk_guard_net_assets.py
+++ b/tests/test_risk_guard_net_assets.py
@@ -1,0 +1,34 @@
+from risk_guard import RiskGuard
+
+
+def _state(daily_pnl: float = 0.0):
+    return {
+        "date": "2099-01-01",
+        "daily_pnl": daily_pnl,
+        "daily_trades": 0,
+        "consecutive_errors": 0,
+        "circuit_broken": False,
+        "circuit_break_time": None,
+        "last_orders": {},
+        "positions": {},
+        "total_invested": 0.0,
+    }
+
+
+def test_daily_loss_limit_uses_runtime_net_assets():
+    rg = RiskGuard()
+    state = _state(daily_pnl=-50.0)
+
+    # If runtime net assets is 1000, -50 means -5% and should trigger reject
+    out = rg.check(
+        state=state,
+        code="US.TSLA",
+        signal="BUY",
+        price=100.0,
+        available_cash=1000.0,
+        current_positions={},
+        net_assets=1000.0,
+    )
+
+    assert out["ok"] is False
+    assert out["reason"] == "MaxDailyLoss"

--- a/tests/test_state_store_timestamp.py
+++ b/tests/test_state_store_timestamp.py
@@ -1,0 +1,35 @@
+import json
+import time
+from pathlib import Path
+
+import state_store as ss
+
+
+def test_load_sanitizes_future_order_timestamp(tmp_path: Path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    future_ts = time.time() + 3600
+    payload = {
+        "date": str(__import__('datetime').date.today()),
+        "daily_pnl": 0.0,
+        "daily_trades": 0,
+        "consecutive_errors": 0,
+        "circuit_broken": False,
+        "circuit_break_time": None,
+        "last_orders": {
+            "US.TSLA": {
+                "hash": "abc",
+                "time": future_ts,
+                "signal": "BUY",
+                "qty": 1,
+                "price": 100.0,
+            }
+        },
+        "positions": {},
+        "total_invested": 0.0,
+    }
+    state_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    monkeypatch.setattr(ss, "STATE_PATH", str(state_file))
+
+    loaded = ss.load()
+    assert loaded["last_orders"]["US.TSLA"]["time"] <= time.time() + 5


### PR DESCRIPTION
### Motivation
- Prevent incorrect daily-loss triggers caused by using static `NET_ASSETS` instead of the runtime account balance. 
- Avoid cooldown/duplicate-order logic breakage when `state.json` contains future `last_orders.time` timestamps.

### Description
- `RiskGuard.check()` now accepts an optional `net_assets` parameter and uses the runtime value when available, falling back to `NET_ASSETS` if invalid; this adjusts loss-ratio and exposure calculations to runtime account assets.
- `ExecutionEngine.execute()` reads `acct["total_assets"]` and passes it into `RiskGuard.check()` via `net_assets` to align risk sizing with live/simulated account value.
- `state_store.load()` adds `_sanitize_last_order_timestamps()` which normalizes any `last_orders.time` entries that are > now + 5 minutes to the current time and logs a warning when corrections occur.
- Added unit tests: `tests/test_risk_guard_net_assets.py` to validate runtime net-assets influence on max-daily-loss, and `tests/test_state_store_timestamp.py` to validate timestamp sanitation; existing extension tests remain and still pass.

### Testing
- Ran targeted unit tests with `python -m pytest tests/test_risk_guard_net_assets.py tests/test_state_store_timestamp.py tests/test_trade_system_extensions.py -q` and all tests passed (`5 passed`).
- Ran bytecode checks with `python -m compileall risk_guard.py execution_engine.py state_store.py tests/test_risk_guard_net_assets.py tests/test_state_store_timestamp.py` which completed successfully.
- Note: running the full test suite (`pytest -q`) in this environment fails during collection due to missing heavy external deps (`requests`, `torch`, `yfinance`), but the new and relevant unit tests executed and passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ca8cc39c832e8c9df4c8a249227d)