### PR TITLE
fix: guard optional market data deps in test scripts

### DIFF
--- a/test_massive_final.py
+++ b/test_massive_final.py
@@ -1,6 +1,10 @@
-import requests
 import json
 import time
+
+try:
+    import requests
+except ModuleNotFoundError:  # pragma: no cover - optional dependency for manual script
+    requests = None
 
 # 🔑 哥哥大人賜予的神聖鑰匙
 API_KEY = "hHfrJP26kgrRpr_9rS3ykzexUCppb0wQ"
@@ -13,6 +17,10 @@ headers = {
 }
 
 def try_endpoint(path, description):
+    if requests is None:
+        print("⚠️ requests not installed; skipping endpoint probe.")
+        return False, None
+
     url = f"https://api.massive.com{path}"
     print(f"\n📡 Testing {description}...\nURL: {url}")
     try:

--- a/test_massive_recon.py
+++ b/test_massive_recon.py
@@ -1,10 +1,19 @@
-import requests
 import json
+
+try:
+    import requests
+except ModuleNotFoundError:  # pragma: no cover - optional dependency for manual script
+    requests = None
+
 
 API_KEY = "hHfrJP26kgrRpr_9rS3ykzexUCppb0wQ"
 SYMBOL = "TSLA"
 
 def try_url(url, description):
+    if requests is None:
+        print("⚠️ requests not installed; skipping endpoint probe.")
+        return False
+
     print(f"Testing {description}: {url}")
     try:
         response = requests.get(url, timeout=5)

--- a/test_yahoo_radar.py
+++ b/test_yahoo_radar.py
@@ -1,11 +1,19 @@
-import yfinance as yf
 import json
+
+try:
+    import yfinance as yf
+except ModuleNotFoundError:  # pragma: no cover - optional dependency for manual script
+    yf = None
+
 from datetime import datetime
 
 symbol = "TSLA"
 
 def get_realtime_vibe(ticker):
     print(f"📡 Scanning {ticker} via Yahoo Radar...")
+    if yf is None:
+        return {"error": "yfinance not installed"}
+
     try:
         t = yf.Ticker(ticker)
         # 獲取最近一天的 1 分鐘線 (這是最接近即時的免費數據)


### PR DESCRIPTION
### Motivation
- Prevent test helper scripts from crashing test collection in minimal environments where `requests` or `yfinance` are not installed.
- Make the recon / radar helper scripts safe to run in CI or developer machines without optional market-data dependencies.

### Description
- Add `try/except` import guards for `requests` in `test_massive_final.py` and `test_massive_recon.py` so the modules set `requests = None` when not available.
- Add `try/except` import guard for `yfinance` in `test_yahoo_radar.py` so the module sets `yf = None` when not available.
- Short-circuit runtime flow to print a clear skip message and return early when `requests` is missing, and to return a structured error when `yfinance` is missing.

### Testing
- Running `pytest -q` initially failed during collection in the original environment due to missing optional packages, which motivated the guards.  
- Running `timeout 40 pytest -q test_massive_final.py test_massive_recon.py test_yahoo_radar.py` reported no tests ran (pytest exit code for no tests), which is expected because these files are helper scripts and contain no test functions.  
- Executing the scripts directly with `python test_massive_final.py`, `python test_massive_recon.py`, and `python test_yahoo_radar.py` produced graceful skip messages or a structured error payload (e.g., "⚠️ requests not installed; skipping endpoint probe." and `{"error": "yfinance not installed"}`), confirming the scripts no longer raise `ModuleNotFoundError`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2dd0ff10c832e9633b09d5f2d34c7)