### PR TITLE
fix: add TTL kline cache to reduce repeated market data fetches (#29)

### DIFF
--- a/config.py
+++ b/config.py
@@ -105,6 +105,7 @@ POSITION_SYNC_INTERVAL = 300    # 每 5 分鐘強制同步持倉（秒）
 ORDER_COOLDOWN_HOURS = 1        # 同股票買入冷卻時間（小時），避免 OrderPending 過長
 LOOP_INTERVAL    = 300          # 主循環間隔（秒）
 KLINE_COUNT      = 500          # 取 K 線數量
+KLINE_CACHE_TTL_SECONDS = int(os.environ.get("KLINE_CACHE_TTL_SECONDS", "180"))
 
 # 緊急風控參數
 EMERGENCY_DAILY_LOSS_PCT = float(os.environ.get("EMERGENCY_DAILY_LOSS_PCT", "0.05"))

--- a/quant_v2.py
+++ b/quant_v2.py
@@ -25,7 +25,7 @@ from datetime import datetime, timedelta
 from config import (
     STOCK_LIST, KLINE_COUNT, RETRAIN_INTERVAL, LOOP_INTERVAL,
     RISK_CONFIG, OPEND_HOST, OPEND_PORT, TRADE_MODE, LOG_PATH,
-    print_config
+    KLINE_CACHE_TTL_SECONDS, print_config
 )
 from execution_engine import ExecutionEngine
 from massive_client import MassiveClient
@@ -189,6 +189,7 @@ class QuantV2:
         self.model_mgr = ModelManager()
         self.quote_ctx = None
         self.massive   = None
+        self.kline_cache = {}
 
     def boot(self):
         print_config()
@@ -212,7 +213,15 @@ class QuantV2:
         return True
 
     def fetch_kline(self, code: str) -> pd.DataFrame:
-        """取 K 線：先嘗試 Futu，失敗自動 fallback 至 Massive"""
+        """取 K 線：先嘗試快取與 Futu，失敗自動 fallback 至 Massive"""
+        now = time.time()
+        cached = self.kline_cache.get(code)
+        if cached:
+            cached_at, cached_df = cached
+            if now - cached_at <= KLINE_CACHE_TTL_SECONDS:
+                self.log.info(f"💾 [Kline cache] {code} 命中，沿用 {len(cached_df)} 條")
+                return cached_df.copy()
+
         # 1. Futu 優先
         if self.quote_ctx:
             try:
@@ -220,6 +229,8 @@ class QuantV2:
                     code, ktype=ft.KLType.K_DAY, max_count=KLINE_COUNT
                 )
                 if ret == ft.RET_OK and not data.empty:
+                    data = data.sort_values("time_key").reset_index(drop=True)
+                    self.kline_cache[code] = (now, data.copy())
                     self.log.info(f"📥 [Futu] {code} K線 {len(data)} 條")
                     return data
                 else:
@@ -239,6 +250,7 @@ class QuantV2:
                 df = pd.DataFrame(bars)
                 # Massive 返回最新在前，要反轉
                 df = df.sort_values("time_key").reset_index(drop=True)
+                self.kline_cache[code] = (now, df.copy())
                 self.log.info(f"📥 [Massive] {code} K線 {len(df)} 條")
                 return df
         except Exception as e:

--- a/tests/test_quant_v2_kline_cache.py
+++ b/tests/test_quant_v2_kline_cache.py
@@ -1,0 +1,114 @@
+import sys
+import types
+
+import pandas as pd
+
+
+fake_futu = types.SimpleNamespace(
+    RET_OK=0,
+    KLType=types.SimpleNamespace(K_DAY="K_DAY"),
+)
+sys.modules.setdefault("futu", fake_futu)
+
+fake_xgb = types.ModuleType("xgboost")
+
+
+class _FakeXGBClassifier:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+fake_xgb.XGBClassifier = _FakeXGBClassifier
+sys.modules.setdefault("xgboost", fake_xgb)
+
+fake_sklearn = types.ModuleType("sklearn")
+fake_pre = types.ModuleType("sklearn.preprocessing")
+fake_model_selection = types.ModuleType("sklearn.model_selection")
+fake_metrics = types.ModuleType("sklearn.metrics")
+
+class _FakeStandardScaler:
+    def fit_transform(self, x):
+        return x
+    def transform(self, x):
+        return x
+
+def _fake_split(X, y, test_size=0.2, shuffle=False):
+    split = int(len(X) * (1 - test_size))
+    return X[:split], X[split:], y[:split], y[split:]
+
+def _fake_accuracy_score(y_true, y_pred):
+    return 0.5
+
+fake_pre.StandardScaler = _FakeStandardScaler
+fake_model_selection.train_test_split = _fake_split
+fake_metrics.accuracy_score = _fake_accuracy_score
+
+sys.modules.setdefault("sklearn", fake_sklearn)
+sys.modules.setdefault("sklearn.preprocessing", fake_pre)
+sys.modules.setdefault("sklearn.model_selection", fake_model_selection)
+sys.modules.setdefault("sklearn.metrics", fake_metrics)
+
+fake_requests = types.ModuleType("requests")
+sys.modules.setdefault("requests", fake_requests)
+
+import quant_v2 as qv2
+
+
+class _QuoteCtx:
+    def __init__(self):
+        self.calls = 0
+
+    def request_history_kline(self, code, ktype=None, max_count=None):
+        self.calls += 1
+        data = pd.DataFrame(
+            {
+                "time_key": ["2026-01-01", "2026-01-02"],
+                "open": [1.0, 2.0],
+                "high": [1.2, 2.2],
+                "low": [0.9, 1.9],
+                "close": [1.1, 2.1],
+                "volume": [100, 200],
+            }
+        )
+        return qv2.ft.RET_OK, data, ""
+
+
+class _Massive:
+    def get_kline(self, *args, **kwargs):
+        raise AssertionError("massive fallback should not be called when cache is valid")
+
+
+def test_fetch_kline_uses_cache_within_ttl(monkeypatch):
+    monkeypatch.setattr(qv2, "KLINE_CACHE_TTL_SECONDS", 60)
+
+    engine = qv2.QuantV2()
+    engine.quote_ctx = _QuoteCtx()
+    engine.massive = _Massive()
+
+    first = engine.fetch_kline("US.TSLA")
+    second = engine.fetch_kline("US.TSLA")
+
+    assert not first.empty
+    assert not second.empty
+    assert engine.quote_ctx.calls == 1
+
+
+def test_fetch_kline_refreshes_cache_after_ttl(monkeypatch):
+    monkeypatch.setattr(qv2, "KLINE_CACHE_TTL_SECONDS", 1)
+
+    clock = {"value": 1000.0}
+
+    def _fake_time():
+        return clock["value"]
+
+    monkeypatch.setattr(qv2.time, "time", _fake_time)
+
+    engine = qv2.QuantV2()
+    engine.quote_ctx = _QuoteCtx()
+    engine.massive = _Massive()
+
+    engine.fetch_kline("US.TSLA")
+    clock["value"] += 2
+    engine.fetch_kline("US.TSLA")
+
+    assert engine.quote_ctx.calls == 2


### PR DESCRIPTION
### Motivation
- Reduce redundant K-line API calls observed in live loops and improve resilience when Futu is flaky by adding a bounded in-memory cache per symbol.
- Make K-line freshness configurable so operators can tune trade-off between API load and data staleness.

### Description
- Added `KLINE_CACHE_TTL_SECONDS` (default 180s) in `config.py` to configure the cache TTL.
- Implemented an in-memory per-symbol K-line cache (`self.kline_cache`) in `QuantV2.fetch_kline()` that is checked before fetching and refreshed after successful Futu or Massive fetches, and that stores normalized `time_key`-ordered DataFrames (`quant_v2.py`).
- Normalized returned K-line ordering by `time_key` prior to caching to ensure downstream feature generation receives consistent data.
- Added unit tests `tests/test_quant_v2_kline_cache.py` that stub heavy external deps and validate cache hit within TTL and cache refresh after TTL expiry.

### Testing
- Ran the full test collection with `pytest -q`, which initially failed due to missing heavy runtime dependencies (e.g. `requests`, `torch`, `yfinance`) in this environment.
- Ran focused tests with `PYTHONPATH=. pytest -q tests/test_quant_v2_kline_cache.py tests/test_state_store_timestamp.py`, and the targeted test set passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e6082ff8832ea2265d6fc025b31a)