### PR TITLE
[Fix] Normalize fallback indicators to avoid all-NaN columns

### DIFF
--- a/tests/test_indicator_fallback_normalization.py
+++ b/tests/test_indicator_fallback_normalization.py
@@ -1,0 +1,57 @@
+import pandas as pd
+
+from v3_pipeline.features.indicators import REQUIRED_COLUMNS, TechnicalIndicatorGenerator
+
+
+def _build_ohlcv(close_values, volume_values):
+    n = len(close_values)
+    return pd.DataFrame(
+        {
+            "Date": pd.date_range("2024-01-01", periods=n, freq="min"),
+            "Open": close_values,
+            "High": close_values,
+            "Low": close_values,
+            "Close": close_values,
+            "Volume": volume_values,
+        }
+    )
+
+
+def _assert_no_all_nan_indicator_columns(df: pd.DataFrame) -> None:
+    indicator_columns = [c for c in df.columns if c not in REQUIRED_COLUMNS]
+    assert indicator_columns, "expected fallback to generate indicator columns"
+    assert all(not df[col].isna().all() for col in indicator_columns)
+
+
+def test_fallback_flat_close_series_has_no_all_nan_indicators(monkeypatch):
+    generator = TechnicalIndicatorGenerator()
+    monkeypatch.setattr(generator, "use_talib", False)
+
+    source = _build_ohlcv(close_values=[100.0] * 60, volume_values=[1000.0] * 60)
+    featured = generator.generate(source)
+
+    _assert_no_all_nan_indicator_columns(featured)
+
+
+
+def test_fallback_increasing_close_series_has_no_all_nan_indicators(monkeypatch):
+    generator = TechnicalIndicatorGenerator()
+    monkeypatch.setattr(generator, "use_talib", False)
+
+    close_values = [100.0 + i for i in range(60)]
+    source = _build_ohlcv(close_values=close_values, volume_values=[1000.0] * 60)
+    featured = generator.generate(source)
+
+    _assert_no_all_nan_indicator_columns(featured)
+
+
+
+def test_fallback_zero_volume_series_has_no_all_nan_indicators(monkeypatch):
+    generator = TechnicalIndicatorGenerator()
+    monkeypatch.setattr(generator, "use_talib", False)
+
+    close_values = [100.0 + (i % 3) for i in range(60)]
+    source = _build_ohlcv(close_values=close_values, volume_values=[0.0] * 60)
+    featured = generator.generate(source)
+
+    _assert_no_all_nan_indicator_columns(featured)

--- a/v3_pipeline/README.md
+++ b/v3_pipeline/README.md
@@ -85,3 +85,11 @@
 - 會執行：資料完整性檢查 + HistoryPrimer 修補、CosineAnnealing LR、Gradient Clipping、Early Stopping
 - 輸出摘要：`v3_pipeline/reports/training_summary.json`
 - 輸出分佈圖：`v3_pipeline/reports/mse_distribution_111.svg`
+
+## Indicator Generation Caveats
+- When TA-Lib is unavailable, `TechnicalIndicatorGenerator` uses a pandas fallback implementation.
+- After fallback indicator computation, generated indicator columns are normalized by replacing `+/-inf` with `NaN`.
+- If a generated indicator is entirely `NaN` (for example, due to flat price action, zero volume, or denominator collapse), the fallback post-pass applies one of two policies:
+  - Fill with a documented neutral default when available (e.g., `RSI_14=50`, `MFI_14=50`, trend/volatility deltas as `0`, `WILLR_14=-50`).
+  - Drop the indicator column and emit a warning when no neutral default is defined.
+- Base OHLCV columns (`Date/Open/High/Low/Close/Volume`) are intentionally left untouched by this normalization pass.

--- a/v3_pipeline/features/indicators.py
+++ b/v3_pipeline/features/indicators.py
@@ -7,6 +7,30 @@ import pandas as pd
 
 REQUIRED_COLUMNS = ["Date", "Open", "High", "Low", "Close", "Volume"]
 
+# Neutral fallback defaults used when an indicator column is entirely NaN in the
+# pandas-only path (e.g. flat prices, no volume, short warm-up windows).
+FALLBACK_ALL_NAN_DEFAULTS = {
+    "SMA_5": 0.0,
+    "SMA_10": 0.0,
+    "SMA_20": 0.0,
+    "EMA_12": 0.0,
+    "EMA_26": 0.0,
+    "RSI_14": 50.0,
+    "MACD": 0.0,
+    "MACD_SIGNAL": 0.0,
+    "MACD_HIST": 0.0,
+    "BB_UPPER": 0.0,
+    "BB_MIDDLE": 0.0,
+    "BB_LOWER": 0.0,
+    "ATR_14": 0.0,
+    "ADX_14": 0.0,
+    "CCI_14": 0.0,
+    "MFI_14": 50.0,
+    "OBV": 0.0,
+    "ROC_10": 0.0,
+    "WILLR_14": -50.0,
+}
+
 
 def _build_stderr_logger(name: str) -> logging.Logger:
     logger = logging.getLogger(name)
@@ -158,7 +182,35 @@ class TechnicalIndicatorGenerator:
         highest = high.rolling(14).max()
         lowest = low.rolling(14).min()
         df["WILLR_14"] = -100 * (highest - close) / (highest - lowest).replace(0, np.nan)
+        self._normalize_fallback_indicators(df)
         return df
+
+    def _normalize_fallback_indicators(self, df: pd.DataFrame) -> None:
+        indicator_columns = [column for column in df.columns if column not in REQUIRED_COLUMNS]
+
+        # Risk boundary: normalize only generated indicator features so raw OHLCV
+        # columns keep their original values for downstream risk/execution logic.
+        if indicator_columns:
+            df.loc[:, indicator_columns] = df[indicator_columns].replace([np.inf, -np.inf], np.nan)
+
+        for column in indicator_columns:
+            if not df[column].isna().all():
+                continue
+
+            if column in FALLBACK_ALL_NAN_DEFAULTS:
+                default_value = FALLBACK_ALL_NAN_DEFAULTS[column]
+                df[column] = default_value
+                self.logger.warning(
+                    "Fallback indicator '%s' was all-NaN; filled with neutral default %s",
+                    column,
+                    default_value,
+                )
+            else:
+                df.drop(columns=[column], inplace=True)
+                self.logger.warning(
+                    "Fallback indicator '%s' was all-NaN and has no neutral default; dropping column",
+                    column,
+                )
 
     def indicator_columns(self, data: pd.DataFrame) -> List[str]:
         return [col for col in data.columns if col not in REQUIRED_COLUMNS]


### PR DESCRIPTION
### Motivation
- Prevent pandas-only indicator generation from producing all-NaN feature columns that break downstream live preprocessing and risk gates.
- Ensure generated indicators are safe for live pipelines while leaving base OHLCV columns unchanged.

### Description
- Added `FALLBACK_ALL_NAN_DEFAULTS` mapping of neutral defaults for common indicators and documented the policy in `v3_pipeline/features/indicators.py`.
- Implemented `_normalize_fallback_indicators` called at the end of the pandas fallback path to replace `+/-inf` with `NaN`, fill all-NaN indicator columns with documented neutral defaults when available, or drop unknown all-NaN indicators and emit a warning, keeping `Date/Open/High/Low/Close/Volume` untouched.
- Added unit tests `tests/test_indicator_fallback_normalization.py` covering flat close series, strictly increasing close series, and zero-volume series to assert no generated indicator column is entirely NaN.
- Documented the fallback behavior and caveats under "Indicator Generation Caveats" in `v3_pipeline/README.md`.

### Testing
- Ran the full test suite with `python -m pytest tests/` and all tests passed (`14 passed`).
- Executed a `cProfile` profiling run for the fallback indicator generation path to validate performance impact; profiling completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2eb14e45083219e310ce788fb1965)