### PR TITLE
[Fix] Include stock code in successful order logs

### DIFF
--- a/execution_engine.py
+++ b/execution_engine.py
@@ -266,7 +266,7 @@ class ExecutionEngine:
         if result.get("status") == "OK":
             ss.record_order(state, code, signal, qty, price)
             self.risk.record_success(state)
-            log.info(f"✅ 下單成功: #{result.get('order_id')}")
+            log.info(f"✅ 下單成功: {signal} {qty}股 {code} @ ${price:.2f} -> #{result.get('order_id')}")
         else:
             self.risk.record_error(state)
 

--- a/tests/test_execution_engine_emergency.py
+++ b/tests/test_execution_engine_emergency.py
@@ -52,3 +52,27 @@ def test_check_emergency_triggers_liquidates_on_daily_loss(monkeypatch):
 
     assert out["triggered"] is True
     assert out["reason"] == "MaxDailyLossEmergency"
+
+
+def test_execute_signal_success_log_contains_stock_code(monkeypatch, caplog):
+    engine = ee.ExecutionEngine()
+
+    monkeypatch.setattr(engine, "get_account_info", lambda: {"cash": 100000, "total_assets": 100000, "power": 100000})
+    monkeypatch.setattr(engine, "get_positions", lambda: {})
+    monkeypatch.setattr(
+        engine.risk,
+        "check",
+        lambda **kwargs: {"ok": True, "qty": 1},
+    )
+    monkeypatch.setattr(engine, "_place_with_retry", lambda code, signal, qty, price: {"status": "OK", "order_id": "OID-LOG-1"})
+    monkeypatch.setattr(ee.ss, "load", lambda: {})
+    monkeypatch.setattr(ee.ss, "record_order", lambda state, code, signal, qty, price: None)
+    monkeypatch.setattr(ee.ss, "save", lambda state: None)
+
+    with caplog.at_level("INFO", logger="ExecutionEngine"):
+        monkeypatch.setattr(engine, "close_short_if_needed", lambda code, positions: True)
+        result = engine.execute("US.TSLA", "BUY", 250.0)
+
+    assert result["status"] == "OK"
+    assert "US.TSLA" in caplog.text
+    assert "BUY" in caplog.text


### PR DESCRIPTION
### Motivation
- Improve post-trade observability because the success log previously emitted only an order id, making audits and debugging harder and leaving logs missing the traded symbol (issue #29). 
- Ensure trading-related changes include a unit test as required by repository conventions.

### Description
- Change the success log in `ExecutionEngine.execute` to include `signal`, `qty`, `code`, and `price` so successful orders clearly identify the traded symbol (`execution_engine.py`).
- Add a regression test `test_execute_signal_success_log_contains_stock_code` to `tests/test_execution_engine_emergency.py` which mocks the flow and asserts the emitted log contains the stock code and action.
- Adjust test mocks to use the existing `RiskGuard.check` and bypass short-close logic for the unit test.

### Testing
- Ran the test suite with `python -m pytest tests/` and the tests passed, including the new regression test (19 passed).
- The new test verifies logs captured at `INFO` level contain both the stock code and `BUY` action when a mocked order returns success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b38f1ce1348321a91f00fbc2eeca7f)