### PR TITLE
[Fix] Enforce bounded Futu reconnect budget and main-loop offline fallback

### DIFF
--- a/tests/test_main_loop_trade_bridge.py
+++ b/tests/test_main_loop_trade_bridge.py
@@ -648,3 +648,29 @@ def test_position_cap_blocks_additional_model_entry():
     )
 
     assert not executed
+
+
+def test_reconnect_stops_after_three_failures_and_enables_offline_mode():
+    class _FailReconnectConnector(_DummyConnector):
+        def __init__(self):
+            self.reconnect_calls = 0
+
+        def reconnect(self, **_kwargs):
+            self.reconnect_calls += 1
+            raise RuntimeError("RECONNECT_BUDGET_EXCEEDED")
+
+    connector = _FailReconnectConnector()
+    loop = LiveTradingLoop(
+        model_manager=_DummyModelManager(prediction=101.0),
+        risk_controller=_DummyRiskController(allow_ror=True),
+        futu_connector=connector,
+        feature_generator=_PassFeatureGenerator(),
+        config=LiveConfig(symbol="TSLA", symbols_list=["TSLA"]),
+    )
+
+    for _ in range(5):
+        loop._attempt_reconnect()
+
+    assert loop.futu_reconnect_failures == 3
+    assert loop.broker_offline_fallback_mode is True
+    assert connector.reconnect_calls == 3

--- a/tests/test_trade_system_extensions.py
+++ b/tests/test_trade_system_extensions.py
@@ -52,7 +52,7 @@ def test_paper_trading_and_pnl_report(tmp_path: Path):
     assert (tmp_path / "pnl_report.json").exists()
 
 
-def test_reconnect_backoff(monkeypatch):
+def test_reconnect_backoff_caps_attempts_and_uses_bounded_delays(monkeypatch):
     connector = FutuConnector(config=FutuConfig(trd_env="SIMULATE"))
     sleeps = []
     attempts = {"n": 0}
@@ -69,4 +69,32 @@ def test_reconnect_backoff(monkeypatch):
     connector.reconnect(max_retries=10, base_delay_seconds=5)
 
     assert attempts["n"] == 3
-    assert sleeps == [5, 10]
+    assert sleeps == [2, 4]
+
+
+def test_reconnect_budget_exceeded_raises_deterministic_error(monkeypatch):
+    connector = FutuConnector(config=FutuConfig(trd_env="SIMULATE"))
+    attempts = {"n": 0}
+
+    def fake_connect():
+        attempts["n"] += 1
+        raise RuntimeError("boom")
+
+    clock = {"now": 0.0}
+
+    def fake_time():
+        clock["now"] += 11.0
+        return clock["now"]
+
+    monkeypatch.setattr(connector, "connect", fake_connect)
+    monkeypatch.setattr(connector, "_safe_close_contexts", lambda: None)
+    monkeypatch.setattr("v3_pipeline.core.futu_connector.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("v3_pipeline.core.futu_connector.time.time", fake_time)
+
+    try:
+        connector.reconnect(max_retries=10, base_delay_seconds=5)
+        raise AssertionError("expected reconnect to fail")
+    except RuntimeError as exc:
+        assert "RECONNECT_BUDGET_EXCEEDED" in str(exc)
+
+    assert 1 <= attempts["n"] <= 3

--- a/v3_pipeline/core/futu_connector.py
+++ b/v3_pipeline/core/futu_connector.py
@@ -285,8 +285,20 @@ class FutuConnector:
             return False
 
     def reconnect(self, max_retries: int = 10, base_delay_seconds: int = 5) -> None:
+        hard_attempt_cap = 3
+        hard_elapsed_budget_seconds = 30.0
+        bounded_delays_seconds = (2, 4, 8)
+
+        max_retries = min(max(1, int(max_retries)), hard_attempt_cap)
+        started = time.time()
         last_exc: Optional[Exception] = None
         for attempt in range(1, max_retries + 1):
+            elapsed = time.time() - started
+            if elapsed >= hard_elapsed_budget_seconds:
+                raise RuntimeError(
+                    "RECONNECT_BUDGET_EXCEEDED: "
+                    f"elapsed={elapsed:.2f}s attempts={attempt - 1} budget={hard_elapsed_budget_seconds:.2f}s"
+                )
             try:
                 self.logger.warning("Reconnect attempt %d/%d", attempt, max_retries)
                 self._safe_close_contexts()
@@ -297,10 +309,23 @@ class FutuConnector:
                 last_exc = exc
                 if attempt >= max_retries:
                     break
-                delay = base_delay_seconds * (2 ** (attempt - 1))
+                delay = bounded_delays_seconds[min(attempt - 1, len(bounded_delays_seconds) - 1)]
+                remaining_budget = hard_elapsed_budget_seconds - (time.time() - started)
+                if remaining_budget <= 0:
+                    raise RuntimeError(
+                        "RECONNECT_BUDGET_EXCEEDED: "
+                        f"elapsed={time.time() - started:.2f}s attempts={attempt} budget={hard_elapsed_budget_seconds:.2f}s"
+                    ) from exc
+                delay = min(delay, remaining_budget)
                 self.logger.warning("Reconnect attempt %d failed: %s; retrying in %ss", attempt, exc, delay)
                 time.sleep(delay)
-        raise RuntimeError(f"Reconnect failed after {max_retries} attempts: {last_exc}")
+        elapsed = time.time() - started
+        if elapsed >= hard_elapsed_budget_seconds:
+            raise RuntimeError(
+                "RECONNECT_BUDGET_EXCEEDED: "
+                f"elapsed={elapsed:.2f}s attempts={max_retries} budget={hard_elapsed_budget_seconds:.2f}s"
+            ) from last_exc
+        raise RuntimeError(f"RECONNECT_BUDGET_EXCEEDED: attempts={max_retries}/{hard_attempt_cap}; last_error={last_exc}")
 
     def get_latest_quote(self, symbol: str) -> dict:
         code = f"{self.config.market_prefix}.{symbol}"

--- a/v3_pipeline/core/main_loop.py
+++ b/v3_pipeline/core/main_loop.py
@@ -120,6 +120,8 @@ class LiveTradingLoop:
         }
         self.pnl_tracker = PnLTracker()
         self.paper_trading_simulator = PaperTradingSimulator(starting_cash=self.account_value)
+        self.futu_reconnect_failures = 0
+        self.broker_offline_fallback_mode = False
 
     def start(self) -> None:
         self.futu_connector.connect()
@@ -560,6 +562,9 @@ class LiveTradingLoop:
             self._notify(f"[CRIT] {symbol} moved {move:.2%} in one cycle")
 
     def _check_heartbeat(self) -> None:
+        if self.broker_offline_fallback_mode:
+            self.logger.warning("Broker offline fallback mode active; skip heartbeat reconnect")
+            return
         try:
             ok = self.futu_connector.heartbeat()
             if not ok:
@@ -570,14 +575,22 @@ class LiveTradingLoop:
             self._attempt_reconnect()
 
     def _attempt_reconnect(self) -> None:
+        if self.broker_offline_fallback_mode:
+            return
         try:
-            self.futu_connector.reconnect(max_retries=10, base_delay_seconds=5)
+            self.futu_connector.reconnect(max_retries=3, base_delay_seconds=2)
+            self.futu_reconnect_failures = 0
             self._sync_broker_state()
             orders = self.futu_connector.get_open_orders()
             self.logger.info("Reconnect sync completed: open_orders=%d", len(orders.index))
         except Exception as exc:
-            self.logger.error("Reconnect failed: %s", exc)
+            self.futu_reconnect_failures += 1
+            self.logger.error("Reconnect failed (consecutive=%d): %s", self.futu_reconnect_failures, exc)
             self._notify(f"[RECONNECT_FAIL] {exc}")
+            if self.futu_reconnect_failures >= 3:
+                self.broker_offline_fallback_mode = True
+                self.logger.error("Broker offline fallback mode enabled after %d failed reconnect rounds", self.futu_reconnect_failures)
+                self._notify("[BROKER_OFFLINE] fallback mode enabled")
 
     def _sync_broker_state(self) -> None:
         try:


### PR DESCRIPTION
### Motivation
- Prevent unbounded reconnect storms and long blocking retries when the broker/SDK is unavailable by enforcing a small, deterministic reconnect budget. 
- Make reconnect behavior predictable for monitoring and failover by using bounded delays and a deterministic error token when the budget is exhausted.
- Avoid repeated expensive reconnect attempts from the main loop by tracking consecutive failures and entering a broker-offline fallback mode.

### Description
- Hardened `FutuConnector.reconnect` by enforcing a hard attempt cap of 3, a hard elapsed budget of 30 seconds, and replacing pure exponential backoff with bounded delays `(2s, 4s, 8s)`; the function raises a deterministic `RuntimeError` containing `RECONNECT_BUDGET_EXCEEDED` when budget/cap is exceeded. 
- Tracked elapsed time using `started = time.time()` and ensured each retry respects the remaining budget before sleeping. 
- Added loop-level state to `LiveTradingLoop`: `self.futu_reconnect_failures` and `self.broker_offline_fallback_mode`, and gated heartbeat/reconnect logic so `_attempt_reconnect` stops invoking `reconnect` after 3 consecutive failed rounds and enables fallback mode. 
- Added and updated unit tests: modified `tests/test_trade_system_extensions.py` to assert bounded delays, attempt cap, and deterministic budget-exceeded failures, and extended `tests/test_main_loop_trade_bridge.py` to assert that the main loop stops reconnecting after 3 failures and enables offline fallback mode.

### Testing
- Ran the full test suite with `python -m pytest tests/`, and all automated tests passed (`45 passed, 1 skipped`).
- Executed focused tests `python -m pytest tests/test_trade_system_extensions.py tests/test_main_loop_trade_bridge.py -q`, which passed (`23 passed`).
- New/updated tests assert: max 3 reconnect attempts, bounded delays are used (`[2, 4]` observed in test), deterministic `RECONNECT_BUDGET_EXCEEDED` error on budget exhaustion, and main-loop stops reconnecting after 3 consecutive failures and sets `broker_offline_fallback_mode`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4eb8532fc8321baa82f2fda4ae6b8)