### PR TITLE
 feat: V3.6 量化策略全面升級 (Ernest Chan 書籍理論)

### DIFF
--- a/execution_engine.py
+++ b/execution_engine.py
@@ -13,7 +13,7 @@ import futu as ft
 import logging
 import time
 import state_store as ss
-from risk_guard import RiskGuard
+from risk_guard_v36 import RiskGuardV36
 from config import (
     OPEND_HOST, OPEND_PORT, TRADE_PWD, TRADE_MODE, MARKET, ORDER_COOLDOWN_HOURS,
     EMERGENCY_DAILY_LOSS_PCT, MIN_TOTAL_ASSETS_ALERT
@@ -32,7 +32,7 @@ log = logging.getLogger("ExecutionEngine")
 
 class ExecutionEngine:
     def __init__(self):
-        self.risk = RiskGuard()
+        self.risk = RiskGuardV36()
         self.trade_ctx = None
         self.quote_ctx = None
         self._connected = False

--- a/risk_guard_v36.py
+++ b/risk_guard_v36.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""
+V3.6 整合升級 — risk_guard_v36.py
+====================================
+在原有 RiskGuard 基礎上整合 V3.6 新功能:
+- Kelly Formula 動態倉位 (取代固定 max_position_pct)
+- 交易成本門檻檢查 (預期收益 < 成本 → 拒絕)
+- VaR/CVaR 日風險觸發
+- 市場狀態識別 → 動態策略選擇
+"""
+
+import logging
+import time as _time
+from typing import Dict, Optional, List
+
+import state_store as ss
+from config import RISK_CONFIG, NET_ASSETS
+from v36 import (
+    KellyPositionSizer, TransactionCostCalculator,
+    RiskMetrics, MarketRegimeDetector, load_v36_config
+)
+from v36.kelly_position_sizer import KellyConfig
+from v36.risk_metrics import RiskControlConfig
+
+log = logging.getLogger("RiskGuardV36")
+
+
+class RiskGuardV36:
+    """
+    V3.6 升級版風控守衛
+
+    在原有 RiskGuard 邏輯的基礎上加入:
+    1. Kelly Formula 動態倉位計算
+    2. 交易成本可行性檢查
+    3. VaR/CVaR 日風險觸發
+    4. 市場狀態感知
+    """
+
+    def __init__(self, v36_config_path: Optional[str] = None):
+        self.cfg = RISK_CONFIG
+        self.v36 = load_v36_config(v36_config_path)
+
+        # 初始化 V3.6 模組
+        self.kelly = KellyPositionSizer(KellyConfig(
+            kelly_factor=self.v36.kelly_factor,
+            max_position_per_trade=self.v36.max_position_per_trade,
+            max_total_position=self.v36.max_total_position,
+            max_positions=self.v36.max_positions,
+            risk_per_trade=self.v36.risk_per_trade,
+            max_daily_risk=self.v36.max_daily_risk,
+        ))
+        self.cost_calc = TransactionCostCalculator()
+        self.risk_metrics = RiskMetrics(RiskControlConfig(
+            var_confidence=self.v36.var_confidence,
+            max_drawdown_stop=self.v36.max_drawdown_stop,
+            max_drawdown_pause=self.v36.max_drawdown_pause,
+            max_drawdown_kill=self.v36.max_drawdown_kill,
+        ))
+        self.regime_detector = MarketRegimeDetector()
+
+        log.info(f"✅ RiskGuardV36 初始化 (Kelly={self.v36.kelly_factor}, "
+                 f"MaxPos={self.v36.max_position_per_trade:.0%})")
+
+    def check(
+        self,
+        state: dict,
+        code: str,
+        signal: str,
+        price: float,
+        available_cash: float,
+        current_positions: dict,
+        net_assets: Optional[float] = None,
+        # V3.6 新增參數
+        win_rate: float = 0.55,
+        avg_win: float = 0.0,
+        avg_loss: float = 0.0,
+        expected_return: float = 0.0,
+        market_cap: str = "large_cap",
+        recent_returns: Optional[List[float]] = None,
+        price_history: Optional[List[float]] = None,
+    ) -> dict:
+        """
+        V3.6 增強版全面風控檢查
+
+        新增:
+        - Kelly 動態倉位
+        - 交易成本可行性
+        - VaR 日風險
+        - 市場狀態感知
+        """
+
+        # ─── 1. 熔斷檢查 (沿用原邏輯) ───────────────────────────
+        if ss.is_circuit_broken(state):
+            return self._reject("CircuitBroken")
+
+        # ─── 2. 信號過濾 ─────────────────────────────────────────
+        if signal == "HOLD":
+            return self._reject("HOLD")
+
+        # ─── 3. 每日虧損上限 ─────────────────────────────────────
+        daily_pnl = ss.get_daily_pnl(state)
+        net = float(net_assets or NET_ASSETS)
+        if net <= 0:
+            net = float(NET_ASSETS)
+
+        loss_ratio = daily_pnl / net
+        if loss_ratio < -self.cfg.max_daily_loss_pct:
+            log.warning(f"🛑 每日虧損上限觸發: {loss_ratio:.2%}")
+            if not state.get("circuit_broken"):
+                ss.set_circuit_break(state, True)
+            return self._reject("MaxDailyLoss")
+
+        # ─── 3.5 VaR 日風險檢查 (V3.6 新增) ─────────────────────
+        if recent_returns and len(recent_returns) >= 20:
+            daily_risk_check = self.risk_metrics.check_daily_risk(
+                daily_pnl, recent_returns, net
+            )
+            action = daily_risk_check.get("action", "CONTINUE")
+            if action == "EMERGENCY_LIQUIDATE":
+                ss.set_circuit_break(state, True)
+                ss.save(state)
+                return self._reject("CVaR_EmergencyStop")
+            elif action == "PAUSE_TRADING":
+                return self._reject("VaR_PausedTrading")
+
+        # ─── 4. BUY 信號特定檢查 ─────────────────────────────────
+        if signal == "BUY":
+
+            # 4a. 持倉保護 (沿用原邏輯)
+            existing_qty = current_positions.get(code, {}).get("qty", 0)
+            if existing_qty < 0:
+                return self._reject("ShortPositionExists")
+            if existing_qty > 0:
+                return self._reject("AlreadyLong")
+
+            # 4b. 交易成本可行性檢查 (V3.6 新增)
+            if expected_return > 0:
+                cost_check = self.cost_calc.is_profitable_after_cost(
+                    expected_return=expected_return,
+                    symbol=code,
+                    quantity=max(1, int(net * 0.05 / price)) if price > 0 else 1,
+                    price=price,
+                    market_cap=market_cap,
+                )
+                if not cost_check["profitable"]:
+                    log.warning(
+                        f"⛔ [{code}] 交易成本過高: 預期收益={expected_return:.4%} "
+                        f"< 成本={cost_check['round_trip_cost_with_buffer']:.4%}"
+                    )
+                    return self._reject("CostTooHigh")
+
+            # 4c. 市場狀態感知 (V3.6 新增，僅 log 不阻擋)
+            if price_history and len(price_history) >= 20:
+                regime = self.regime_detector.detect_regime(price_history)
+                log.info(
+                    f"📊 市場狀態: {regime['regime']} "
+                    f"(推薦策略: {regime['recommended_strategies']})"
+                )
+                state.setdefault("v36_regime", {})[code] = regime["regime"]
+
+            # 4d. 總倉位上限
+            total_exposure_val = sum(
+                pos.get("market_val", 0) or pos.get("qty", 0) * pos.get("avg_cost", price)
+                for pos in current_positions.values()
+            )
+            total_exposure = total_exposure_val / net
+            if total_exposure >= self.v36.max_total_position:
+                return self._reject("MaxTotalExposure")
+
+            # 4e. Kelly 動態倉位計算 (V3.6 新增) ──────────────────
+            current_positions_count = len([p for p in current_positions.values()
+                                           if p.get("qty", 0) > 0])
+            daily_risk_used = max(0.0, -loss_ratio)
+
+            if avg_win > 0 and avg_loss > 0:
+                # 有歷史資料 → Kelly 計算
+                kelly_result = self.kelly.calculate_position_size(
+                    win_rate=win_rate,
+                    avg_win=avg_win,
+                    avg_loss=avg_loss,
+                    portfolio_value=net,
+                    tier="verified",
+                    current_total_exposure=total_exposure,
+                    current_positions_count=current_positions_count,
+                    daily_risk_used=daily_risk_used,
+                )
+
+                if kelly_result["reason"] != "ok" or kelly_result["position_value"] <= 0:
+                    return self._reject(f"Kelly_{kelly_result['reason']}")
+
+                max_spend = kelly_result["position_value"]
+                log.info(
+                    f"💰 Kelly 倉位: ${max_spend:,.2f} "
+                    f"({kelly_result['pct_of_portfolio']:.2%}) "
+                    f"[raw={kelly_result['kelly_raw']:.4f}]"
+                )
+            else:
+                # 無歷史資料 → 回退到保守固定比例 (5%)
+                max_spend = net * min(self.v36.max_position_per_trade, 0.05)
+                log.info(f"💰 固定倉位 (無歷史資料): ${max_spend:,.2f}")
+
+            # 不超過可用現金
+            max_spend = min(max_spend, available_cash)
+
+            if max_spend <= 0 or price <= 0:
+                return self._reject("InsufficientCash")
+
+            qty = int(max_spend / price)
+
+            # 自動縮倉
+            if qty < self.cfg.min_qty:
+                if available_cash >= price:
+                    qty = self.cfg.min_qty
+                    log.warning(f"⚠️ 自動縮倉 → {qty} 股")
+                else:
+                    return self._reject("InsufficientQty")
+
+        elif signal == "SELL":
+            pos = current_positions.get(code, {})
+            qty = int(pos.get("qty", 0) or 0)
+            if qty <= 0:
+                if qty < 0:
+                    return self._reject("ShortPositionExists")
+                last_buy = state.get("last_orders", {}).get(code, {})
+                if last_buy.get("signal") == "BUY" and (_time.time() - last_buy.get("time", 0)) < 600:
+                    return self._reject("PositionSyncing")
+                return self._reject("NoPosition")
+        else:
+            return self._reject(f"UnknownSignal:{signal}")
+
+        # ─── 5. 重複下單防護 ─────────────────────────────────────
+        if ss.is_duplicate_order(state, code, signal, qty, price, self.cfg.cooldown_seconds):
+            return self._reject("DuplicateOrder")
+
+        # ─── 6. 止損止盈計算 (沿用原邏輯) ───────────────────────
+        stop_loss = price * (1 - self.cfg.stop_loss_pct)
+        stop_profit = price * (1 + self.cfg.stop_profit_pct)
+
+        log.info(
+            f"✅ V3.6 風控通過 | {code} {signal} {qty}股 @ ${price:.2f} | "
+            f"SL: ${stop_loss:.2f} | TP: ${stop_profit:.2f}"
+        )
+
+        return {
+            "ok": True,
+            "qty": qty,
+            "stop_loss": stop_loss,
+            "stop_profit": stop_profit,
+        }
+
+    def record_error(self, state: dict):
+        count = ss.record_error(state)
+        log.warning(f"⚠️ 連續錯誤: {count}/{self.cfg.max_consecutive_errors}")
+        if count >= self.cfg.max_consecutive_errors:
+            ss.set_circuit_break(state, True)
+        ss.save(state)
+
+    def record_success(self, state: dict):
+        ss.reset_errors(state)
+        ss.save(state)
+
+    @staticmethod
+    def _reject(reason: str) -> dict:
+        log.warning(f"⛔ V3.6 風控拒絕: {reason}")
+        return {"ok": False, "reason": reason, "qty": 0}

--- a/tests/test_v36.py
+++ b/tests/test_v36.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+V3.6 單元測試套件
+測試 Kelly、交易成本、風險度量、績效評估及回測驗證等功能。
+"""
+
+import unittest
+import numpy as np
+from v36 import (
+    KellyPositionSizer,
+    TransactionCostCalculator,
+    RiskMetrics,
+    PerformanceMetrics,
+    BacktestValidator,
+    MarketRegimeDetector
+)
+
+class TestV36Modules(unittest.TestCase):
+    
+    def test_kelly_position_sizer(self):
+        sizer = KellyPositionSizer()
+        
+        # Win rate: 55%, Avg Win: 100, Avg Loss: 80, Portfolio: 100000
+        # b = 100 / 80 = 1.25
+        # p = 0.55, q = 0.45
+        # Kelly raw = (1.25 * 0.55 - 0.45) / 1.25 = (0.6875 - 0.45) / 1.25 = 0.2375 / 1.25 = 0.19
+        
+        kelly_raw = sizer.calculate_kelly(win_rate=0.55, avg_win=100.0, avg_loss=80.0)
+        self.assertAlmostEqual(kelly_raw, 0.19, places=4)
+        
+        result = sizer.calculate_position_size(
+            win_rate=0.55,
+            avg_win=100.0,
+            avg_loss=80.0,
+            portfolio_value=100000.0,
+            tier="verified"
+        )
+        # verified tier: 50% kelly_pct
+        # kelly_factor: 0.5 (half kelly)
+        # adjusted = 0.19 * 0.50 * 0.5 = 0.0475
+        
+        self.assertEqual(result["reason"], "ok")
+        self.assertAlmostEqual(result["kelly_adjusted"], 0.0475, places=4)
+        self.assertAlmostEqual(result["position_value"], 4750.0, places=2)
+
+    def test_transaction_cost(self):
+        calc = TransactionCostCalculator()
+        
+        # 100 shares @ $150
+        cost = calc.calculate_total_cost("US.AAPL", 100, 150.0, "large_cap", "BUY")
+        trade_value = 15000.0
+        
+        # US Stock Commission: 0.1% -> 15.0
+        # Slippage large cap: 0.05% -> 7.5
+        # Total cost: 22.5
+        
+        self.assertAlmostEqual(cost["trade_value"], 15000.0)
+        self.assertAlmostEqual(cost["total_cost"], 22.5)
+        self.assertAlmostEqual(cost["cost_rate"], 0.0015, places=4)
+
+    def test_risk_metrics(self):
+        risk = RiskMetrics()
+        np.random.seed(42)
+        returns = np.random.normal(0.001, 0.02, 1000).tolist()
+        
+        var_res = risk.calculate_var(returns, portfolio_value=100000, confidence_level=0.95)
+        self.assertGreater(var_res["var_dollar"], 0)
+        self.assertTrue("historical" in var_res["method"])
+        
+        cvar_res = risk.calculate_cvar(returns, portfolio_value=100000, confidence_level=0.95)
+        self.assertGreater(cvar_res["cvar_dollar"], var_res["var_dollar"])
+        
+        # Test max drawdown
+        equity = [100, 110, 90, 80, 120]
+        mdd_res = risk.calculate_max_drawdown(equity)
+        # 峰值 110, 谷底 80
+        # DD = (80 - 110) / 110 = -30 / 110 = -0.2727
+        self.assertAlmostEqual(mdd_res["max_drawdown"], -0.272727, places=4)
+        self.assertEqual(mdd_res["peak_idx"], 1)
+        self.assertEqual(mdd_res["trough_idx"], 3)
+
+    def test_performance_metrics(self):
+        perf = PerformanceMetrics()
+        
+        returns = [0.01, -0.005, 0.02, -0.01, 0.015, 0.03, -0.02]
+        metrics = perf.calculate_all_metrics(returns)
+        
+        self.assertTrue("sharpe_ratio" in metrics)
+        self.assertTrue("calmar_ratio" in metrics)
+        self.assertTrue("sortino_ratio" in metrics)
+        
+        # Win rate should be 4 / 7 = 0.5714
+        self.assertAlmostEqual(metrics["win_rate"], 0.5714, places=3)
+        
+    def test_backtest_validator(self):
+        signals = [{"timestamp": 1}, {"timestamp": 2}, {"timestamp": 3}]
+        prices = [{"timestamp": 1}, {"timestamp": 2}, {"timestamp": 3}]
+        
+        res = BacktestValidator.check_look_ahead_bias(signals, prices)
+        self.assertTrue(res["passed"])
+        
+        # Test violation: signal at T=2 using price at T=1?
+        # Actually violation is signal > price time.
+        signals_bad = [{"timestamp": 1}, {"timestamp": 3}, {"timestamp": 4}]
+        res_bad = BacktestValidator.check_look_ahead_bias(signals_bad, prices)
+        self.assertFalse(res_bad["passed"])
+        
+    def test_market_regime(self):
+        detector = MarketRegimeDetector()
+        
+        # Trending up
+        prices_up = np.linspace(100, 200, 30).tolist()
+        res_up = detector.detect_regime(prices_up, lookback=20)
+        self.assertEqual(res_up["regime"], "trending_up")
+        
+        # Sideways (oscillation)
+        prices_side = [100 + 5 * np.sin(i) for i in range(30)]
+        res_side = detector.detect_regime(prices_side, lookback=20)
+        self.assertEqual(res_side["regime"], "sideways")
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/v36/__init__.py
+++ b/v36/__init__.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+Kiro-Quant V3.6 — 全新量化交易策略模組
+==========================================
+根據《量化交易：如何建立自己的演算法交易業務》Ernest Chan 書籍優化
+
+模組:
+- KellyPositionSizer: Kelly Formula 資金管理 (第六章)
+- TransactionCostCalculator: 交易成本模型 (第三章)
+- RiskMetrics: VaR/CVaR/MDD 風險度量 (第六章)
+- PerformanceMetrics: 績效評估指標 (第二/三章)
+- MarketRegimeDetector: 市場狀態識別 (第七章)
+- BacktestEngine: 無偏差回測框架 (第三章)
+- V36Config: 完整策略配置 (第七章)
+"""
+
+from .kelly_position_sizer import KellyPositionSizer
+from .transaction_cost import TransactionCostCalculator
+from .risk_metrics import RiskMetrics
+from .performance_metrics import PerformanceMetrics
+from .market_regime import MarketRegimeDetector
+from .backtest_engine import BacktestEngine, BacktestValidator
+from .strategy_config import V36Config, load_v36_config
+
+__version__ = "3.6.0"
+
+__all__ = [
+    "KellyPositionSizer",
+    "TransactionCostCalculator",
+    "RiskMetrics",
+    "PerformanceMetrics",
+    "MarketRegimeDetector",
+    "BacktestEngine",
+    "BacktestValidator",
+    "V36Config",
+    "load_v36_config",
+]

--- a/v36/backtest_engine.py
+++ b/v36/backtest_engine.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""
+V3.6 — 無偏差回測框架 (根據第三章)
+=======================================
+回測陷阱防範:
+1. 前瞻偏差 (Look-ahead Bias) 檢查
+2. 生存者偏差 (Survivorship Bias) 檢查
+3. 數據窺探偏差 (Data Snooping) — 樣本外測試
+4. Walk-forward Analysis
+
+回測流程:
+1. 數據切分 (Train 70% / Test 30%)
+2. 信號生成 (防止前瞻偏差)
+3. 交易成本扣除
+4. 績效評估
+5. 樣本外驗證
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Callable, Tuple
+
+import numpy as np
+
+from .transaction_cost import TransactionCostCalculator, CostConfig
+from .performance_metrics import PerformanceMetrics, PerformanceThresholds
+from .risk_metrics import RiskMetrics, RiskControlConfig
+
+log = logging.getLogger("V36.Backtest")
+
+
+@dataclass
+class BacktestConfig:
+    """回測配置"""
+    train_test_split: float = 0.7        # 訓練/測試比例
+    walk_forward: bool = True            # Walk-forward 分析
+    walk_forward_windows: int = 5        # Walk-forward 窗口數
+    cost_included: bool = True           # 包含交易成本
+    initial_capital: float = 100000.0    # 初始資金
+    default_quantity: int = 100          # 默認下單量
+    default_market_cap: str = "large_cap"
+
+
+class BacktestValidator:
+    """
+    回測驗證器
+
+    防止書籍提到的各種回測偏差
+    """
+
+    @staticmethod
+    def check_look_ahead_bias(
+        signals: List[Dict],
+        prices: List[Dict],
+    ) -> Dict:
+        """
+        前瞻偏差檢查
+
+        確保信號不會使用未來數據
+        信號時間必須 <= 數據時間
+        """
+        violations = []
+        for i in range(len(signals) - 1):
+            sig_time = signals[i].get("timestamp", 0)
+            price_time = prices[i].get("timestamp", 0) if i < len(prices) else 0
+
+            if sig_time > price_time and price_time > 0:
+                violations.append({
+                    "index": i,
+                    "signal_time": sig_time,
+                    "price_time": price_time,
+                })
+
+        passed = len(violations) == 0
+        if not passed:
+            log.warning(f"⚠️ 前瞻偏差: {len(violations)} 個違規")
+
+        return {
+            "check": "look_ahead_bias",
+            "passed": passed,
+            "violations": violations[:10],  # 最多顯示 10 個
+            "total_violations": len(violations),
+        }
+
+    @staticmethod
+    def check_survivorship_bias(
+        symbols_in_data: List[str],
+        current_listed: List[str],
+        delisted: Optional[List[str]] = None,
+    ) -> Dict:
+        """
+        生存者偏差檢查
+
+        確保包含已退市/破產的股票
+        """
+        if delisted is None:
+            delisted = []
+
+        # 檢查是否有退市股票在數據中
+        has_delisted = any(s in symbols_in_data for s in delisted)
+
+        # 如果所有股票都還在上市 → 可能有生存者偏差
+        suspicious = all(s in current_listed for s in symbols_in_data)
+
+        return {
+            "check": "survivorship_bias",
+            "passed": not suspicious or has_delisted,
+            "warning": "All symbols are currently listed — may have survivorship bias" if suspicious else None,
+            "total_symbols": len(symbols_in_data),
+            "has_delisted": has_delisted,
+        }
+
+    @staticmethod
+    def out_of_sample_test(
+        data: List,
+        train_ratio: float = 0.7,
+    ) -> Tuple[List, List]:
+        """
+        樣本外測試 — 數據切分
+
+        防止數據窺探偏差
+        """
+        split_point = int(len(data) * train_ratio)
+        train_data = data[:split_point]
+        test_data = data[split_point:]
+
+        log.info(f"Data split: Train={len(train_data)}, Test={len(test_data)} ({train_ratio:.0%}/{1-train_ratio:.0%})")
+
+        return train_data, test_data
+
+
+class BacktestEngine:
+    """
+    完整回測引擎
+
+    整合成本模型 + 績效評估 + 風險度量
+    """
+
+    def __init__(self, config: Optional[BacktestConfig] = None):
+        self.config = config or BacktestConfig()
+        self.cost_calculator = TransactionCostCalculator()
+        self.perf_metrics = PerformanceMetrics()
+        self.risk_metrics = RiskMetrics()
+        self.validator = BacktestValidator()
+
+    def run_backtest(
+        self,
+        prices: List[float],
+        signals: List[str],
+        symbol: str = "US.TSLA",
+        initial_capital: Optional[float] = None,
+    ) -> Dict:
+        """
+        執行回測
+
+        參數:
+        - prices: 價格序列
+        - signals: 信號序列 (BUY / SELL / HOLD)
+        - symbol: 股票代碼
+        - initial_capital: 初始資金
+
+        返回:
+        - dict: 完整回測結果
+        """
+        capital = initial_capital or self.config.initial_capital
+
+        if len(prices) != len(signals):
+            return {"error": "prices and signals must have same length"}
+
+        # ─── 回測主循環 ───
+        equity_curve = [capital]
+        returns = []
+        trades = []
+        position = 0  # 0=空倉, >0=持倉
+        entry_price = 0.0
+        entry_idx = 0
+        total_cost = 0.0
+
+        for i in range(len(prices)):
+            signal = signals[i]
+            price = prices[i]
+
+            if signal == "BUY" and position == 0:
+                # 開倉
+                qty = int(capital * 0.1 / price) if price > 0 else 0
+                if qty <= 0:
+                    returns.append(0.0)
+                    equity_curve.append(equity_curve[-1])
+                    continue
+
+                # 計算成本
+                if self.config.cost_included:
+                    cost = self.cost_calculator.calculate_total_cost(
+                        symbol, qty, price, self.config.default_market_cap, "BUY"
+                    )
+                    total_cost += cost["total_cost"]
+
+                position = qty
+                entry_price = price
+                entry_idx = i
+                returns.append(0.0)
+                equity_curve.append(equity_curve[-1])
+
+            elif signal == "SELL" and position > 0:
+                # 平倉
+                pnl = (price - entry_price) * position
+
+                # 扣除成本
+                if self.config.cost_included:
+                    cost = self.cost_calculator.calculate_total_cost(
+                        symbol, position, price, self.config.default_market_cap, "SELL"
+                    )
+                    pnl -= cost["total_cost"]
+                    total_cost += cost["total_cost"]
+
+                trade_return = pnl / (entry_price * position) if entry_price > 0 else 0
+                returns.append(trade_return)
+
+                trades.append({
+                    "entry_idx": entry_idx,
+                    "exit_idx": i,
+                    "entry_price": entry_price,
+                    "exit_price": price,
+                    "quantity": position,
+                    "pnl": round(pnl, 2),
+                    "return": round(trade_return, 6),
+                    "holding_period": i - entry_idx,
+                })
+
+                capital += pnl
+                equity_curve.append(capital)
+                position = 0
+                entry_price = 0.0
+
+            else:
+                # HOLD 或無法執行
+                if position > 0:
+                    unrealized = (price - entry_price) / entry_price if entry_price > 0 else 0
+                    returns.append(unrealized)
+                    equity_curve.append(capital + (price - entry_price) * position)
+                else:
+                    returns.append(0.0)
+                    equity_curve.append(equity_curve[-1])
+
+        # ─── 績效計算 ───
+        trade_returns = [t["return"] for t in trades] if trades else returns
+        metrics = self.perf_metrics.calculate_all_metrics(trade_returns)
+
+        # ─── 風險計算 ───
+        risk_report = self.risk_metrics.full_risk_report(
+            returns, equity_curve, capital
+        )
+
+        # ─── 成本影響 ───
+        gross_pnl = sum(t["pnl"] for t in trades) if trades else 0
+        cost_impact = total_cost / abs(gross_pnl) if gross_pnl != 0 else 0
+
+        result = {
+            "initial_capital": self.config.initial_capital,
+            "final_capital": round(capital, 2),
+            "total_pnl": round(capital - self.config.initial_capital, 2),
+            "total_cost": round(total_cost, 2),
+            "cost_impact": round(cost_impact, 4),
+            "total_trades": len(trades),
+            "trades": trades,
+            "metrics": metrics,
+            "risk": risk_report,
+            "equity_curve": equity_curve,
+        }
+
+        log.info(
+            f"Backtest Complete: PnL=${result['total_pnl']:.2f} "
+            f"Trades={len(trades)} Sharpe={metrics.get('sharpe_ratio', 0):.4f}"
+        )
+
+        return result
+
+    def walk_forward_analysis(
+        self,
+        prices: List[float],
+        signal_generator: Callable,
+        symbol: str = "US.TSLA",
+    ) -> Dict:
+        """
+        Walk-Forward Analysis
+
+        將數據分成多個窗口，在每個窗口上:
+        1. 用 train 數據訓練
+        2. 用 test 數據測試
+
+        參數:
+        - prices: 完整價格序列
+        - signal_generator: 信號生成函數 (prices -> signals)
+        - symbol: 股票代碼
+
+        返回:
+        - dict: 各窗口結果 + 整體結果
+        """
+        n_windows = self.config.walk_forward_windows
+        window_size = len(prices) // n_windows
+
+        if window_size < 50:
+            return {"error": "insufficient data for walk-forward analysis"}
+
+        window_results = []
+        all_test_returns = []
+
+        for w in range(n_windows):
+            start = w * window_size
+            end = min(start + window_size, len(prices))
+            window_prices = prices[start:end]
+
+            # 切分 train/test
+            split = int(len(window_prices) * self.config.train_test_split)
+            train_prices = window_prices[:split]
+            test_prices = window_prices[split:]
+
+            # 生成信號 (只用 train 數據訓練)
+            test_signals = signal_generator(train_prices, test_prices)
+
+            # 回測 test 部分
+            bt_result = self.run_backtest(test_prices, test_signals, symbol)
+
+            # 蒐集結果
+            trade_returns = [t["return"] for t in bt_result.get("trades", [])]
+            all_test_returns.extend(trade_returns)
+
+            window_results.append({
+                "window": w + 1,
+                "train_size": len(train_prices),
+                "test_size": len(test_prices),
+                "pnl": bt_result.get("total_pnl", 0),
+                "trades": bt_result.get("total_trades", 0),
+                "sharpe": bt_result.get("metrics", {}).get("sharpe_ratio", 0),
+            })
+
+        # 整體 OOS 績效
+        overall_metrics = self.perf_metrics.calculate_all_metrics(all_test_returns)
+
+        return {
+            "windows": window_results,
+            "overall_oos_metrics": overall_metrics,
+            "total_oos_trades": len(all_test_returns),
+        }
+
+    def validate_strategy(
+        self,
+        backtest_result: Dict,
+    ) -> Dict:
+        """
+        策略驗證 — 上線前檢查
+
+        返回: 驗證結果
+        """
+        metrics = backtest_result.get("metrics", {})
+        cost_impact = backtest_result.get("cost_impact", 0)
+
+        validation = self.perf_metrics.validate_for_launch(metrics, cost_impact)
+
+        log.info(
+            f"Strategy Validation: {'✅ PASSED' if validation['passed'] else '❌ FAILED'} "
+            f"(failed: {validation.get('failed_checks', [])})"
+        )
+
+        return validation

--- a/v36/kelly_position_sizer.py
+++ b/v36/kelly_position_sizer.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+V3.6 — Kelly Formula 資金管理 (根據第六章)
+============================================
+Kelly Formula: f* = (bp - q) / b
+- f*: 最佳投資比例
+- b: 淨賠率 (net odds)
+- p: 贏的概率
+- q: 輸的概率 = 1 - p
+
+功能:
+1. Kelly 倉位計算 (支援 半 Kelly / 25%~100% Kelly)
+2. 基於歷史績效動態調整
+3. 風險規則鐵律執行
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional, List
+
+import numpy as np
+
+log = logging.getLogger("V36.Kelly")
+
+
+@dataclass
+class KellyConfig:
+    """Kelly 倉位配置"""
+    kelly_factor: float = 0.5          # 半 Kelly (0.25 ~ 1.0)
+    max_position_per_trade: float = 0.15   # 單筆最大倉位 15%
+    max_total_position: float = 0.80       # 最大總倉位 80%
+    max_positions: int = 10                # 最大同時持倉數
+    risk_per_trade: float = 0.02           # 每筆交易風險 ≤ 2%
+    max_daily_risk: float = 0.05           # 單日總風險 ≤ 5%
+    min_win_rate: float = 0.40             # 最低勝率門檻 (低於此不交易)
+    min_trades_for_kelly: int = 30         # 至少 30 筆交易才用 Kelly
+
+
+# 倉位計算規則表
+KELLY_TIERS = {
+    "unverified":   {"kelly_pct": 0.25, "max_position": 0.05},
+    "verified":     {"kelly_pct": 0.50, "max_position": 0.10},
+    "high_conf":    {"kelly_pct": 0.75, "max_position": 0.15},
+    "ultra_conf":   {"kelly_pct": 1.00, "max_position": 0.20},
+}
+
+
+class KellyPositionSizer:
+    """
+    Kelly Formula 倉位管理器
+
+    Kelly Formula: f* = (bp - q) / b
+    """
+
+    def __init__(self, config: Optional[KellyConfig] = None):
+        self.config = config or KellyConfig()
+
+    def calculate_kelly(self, win_rate: float, avg_win: float, avg_loss: float) -> float:
+        """
+        計算原始 Kelly 比例
+
+        參數:
+        - win_rate: 歷史勝率 (0.0 - 1.0)
+        - avg_win: 平均獲利金額
+        - avg_loss: 平均虧損金額 (正數)
+
+        返回:
+        - Kelly 比例 (0.0 - 1.0)
+        """
+        if avg_loss <= 0 or win_rate <= 0 or avg_win <= 0:
+            return 0.0
+
+        b = avg_win / avg_loss  # 淨賠率
+        p = win_rate
+        q = 1 - p
+
+        kelly = (b * p - q) / b
+
+        if kelly < 0:
+            return 0.0
+
+        return kelly
+
+    def calculate_position_size(
+        self,
+        win_rate: float,
+        avg_win: float,
+        avg_loss: float,
+        portfolio_value: float,
+        tier: str = "verified",
+        current_total_exposure: float = 0.0,
+        current_positions_count: int = 0,
+        daily_risk_used: float = 0.0,
+    ) -> Dict:
+        """
+        計算建議倉位大小
+
+        參數:
+        - win_rate: 歷史勝率
+        - avg_win: 平均獲利
+        - avg_loss: 平均虧損 (正數)
+        - portfolio_value: 組合總值
+        - tier: 策略驗證級別 (unverified/verified/high_conf/ultra_conf)
+        - current_total_exposure: 當前總倉位比例
+        - current_positions_count: 當前持倉數量
+        - daily_risk_used: 今日已用風險比例
+
+        返回:
+        - dict: {position_value, kelly_raw, kelly_adjusted, pct_of_portfolio, reason}
+        """
+        result = {
+            "position_value": 0.0,
+            "kelly_raw": 0.0,
+            "kelly_adjusted": 0.0,
+            "pct_of_portfolio": 0.0,
+            "reason": "",
+        }
+
+        # 鐵律 1: 勝率太低不交易
+        if win_rate < self.config.min_win_rate:
+            result["reason"] = f"win_rate ({win_rate:.2%}) < min ({self.config.min_win_rate:.2%})"
+            return result
+
+        # 鐵律 2: 持倉數量上限
+        if current_positions_count >= self.config.max_positions:
+            result["reason"] = f"max_positions ({current_positions_count}/{self.config.max_positions})"
+            return result
+
+        # 鐵律 3: 總倉位上限
+        if current_total_exposure >= self.config.max_total_position:
+            result["reason"] = f"max_total_position ({current_total_exposure:.2%})"
+            return result
+
+        # 鐵律 4: 單日風險上限
+        if daily_risk_used >= self.config.max_daily_risk:
+            result["reason"] = f"max_daily_risk ({daily_risk_used:.2%})"
+            return result
+
+        # 計算原始 Kelly
+        kelly_raw = self.calculate_kelly(win_rate, avg_win, avg_loss)
+        result["kelly_raw"] = kelly_raw
+
+        if kelly_raw <= 0:
+            result["reason"] = "negative_kelly"
+            return result
+
+        # 應用 tier 和 factor
+        tier_config = KELLY_TIERS.get(tier, KELLY_TIERS["unverified"])
+        kelly_adjusted = kelly_raw * tier_config["kelly_pct"] * self.config.kelly_factor
+
+        # 多重上限
+        max_limits = [
+            tier_config["max_position"],
+            self.config.max_position_per_trade,
+            self.config.risk_per_trade / (avg_loss / portfolio_value) if avg_loss > 0 and portfolio_value > 0 else 1.0,
+            self.config.max_total_position - current_total_exposure,
+            self.config.max_daily_risk - daily_risk_used,
+        ]
+
+        kelly_capped = min(kelly_adjusted, min(max_limits))
+        kelly_capped = max(0.0, kelly_capped)
+
+        position_value = portfolio_value * kelly_capped
+
+        result["kelly_adjusted"] = kelly_capped
+        result["pct_of_portfolio"] = kelly_capped
+        result["position_value"] = position_value
+        result["reason"] = "ok"
+
+        log.info(
+            f"Kelly: raw={kelly_raw:.4f} adj={kelly_capped:.4f} "
+            f"→ ${position_value:,.2f} ({kelly_capped:.2%} of portfolio)"
+        )
+
+        return result
+
+    def calculate_from_trades(
+        self,
+        trade_results: List[float],
+        portfolio_value: float,
+        tier: str = "verified",
+        **kwargs,
+    ) -> Dict:
+        """
+        從歷史交易結果直接計算倉位
+
+        trade_results: 每筆交易的盈虧列表 (正=盈利, 負=虧損)
+        """
+        if len(trade_results) < self.config.min_trades_for_kelly:
+            return {
+                "position_value": 0.0,
+                "kelly_raw": 0.0,
+                "kelly_adjusted": 0.0,
+                "pct_of_portfolio": 0.0,
+                "reason": f"insufficient_trades ({len(trade_results)}/{self.config.min_trades_for_kelly})",
+            }
+
+        trades = np.array(trade_results)
+        wins = trades[trades > 0]
+        losses = trades[trades < 0]
+
+        if len(wins) == 0 or len(losses) == 0:
+            return {
+                "position_value": 0.0,
+                "kelly_raw": 0.0,
+                "kelly_adjusted": 0.0,
+                "pct_of_portfolio": 0.0,
+                "reason": "no_wins_or_no_losses",
+            }
+
+        win_rate = len(wins) / len(trades)
+        avg_win = float(np.mean(wins))
+        avg_loss = float(abs(np.mean(losses)))
+
+        return self.calculate_position_size(
+            win_rate=win_rate,
+            avg_win=avg_win,
+            avg_loss=avg_loss,
+            portfolio_value=portfolio_value,
+            tier=tier,
+            **kwargs,
+        )

--- a/v36/market_regime.py
+++ b/v36/market_regime.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+V3.6 — 市場狀態識別 (根據第七章)
+===================================
+不同策略適用於不同市場狀態:
+
+| 策略類型   | 適合市況 | 持有期  |
+|-----------|---------|--------|
+| 均值回歸   | 震盪市   | 1-5 日  |
+| 動量       | 趨勢市   | 5-20 日 |
+| 突破       | 趨勢市   | 5-30 日 |
+| 配對       | 任何     | 1-10 日 |
+
+市場狀態:
+- trending_up:    上升趨勢
+- trending_down:  下降趨勢
+- sideways:       震盪市
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+log = logging.getLogger("V36.Regime")
+
+
+@dataclass
+class RegimeConfig:
+    """市場狀態識別配置"""
+    lookback: int = 20                # 回看期
+    trend_threshold: float = 1.5      # 趨勢強度門檻
+    volatility_high: float = 0.025    # 高波動門檻 (日)
+    volatility_low: float = 0.01      # 低波動門檻 (日)
+    adx_period: int = 14              # ADX 計算週期
+    adx_trend_threshold: float = 25   # ADX > 25 = 趨勢市
+
+
+# 策略映射表
+STRATEGY_MAP = {
+    "trending_up":   ["momentum", "breakout"],
+    "trending_down": ["mean_reversion", "momentum_short"],
+    "sideways":      ["mean_reversion", "pair_trading"],
+    "high_volatility": ["mean_reversion"],
+    "low_volatility":  ["breakout"],
+}
+
+
+class MarketRegimeDetector:
+    """
+    市場狀態識別器
+
+    根據 Ernest Chan 書籍 第七章:
+    Different strategies work in different market regimes.
+    """
+
+    def __init__(self, config: Optional[RegimeConfig] = None):
+        self.config = config or RegimeConfig()
+
+    def detect_regime(
+        self,
+        prices: List[float],
+        lookback: Optional[int] = None,
+    ) -> Dict:
+        """
+        識別當前市場狀態
+
+        參數:
+        - prices: 價格序列
+        - lookback: 回看期
+
+        返回:
+        - dict: {regime, trend_strength, volatility, recommended_strategies}
+        """
+        lb = lookback or self.config.lookback
+
+        if len(prices) < lb + 1:
+            return {
+                "regime": "unknown",
+                "trend_strength": 0.0,
+                "volatility": 0.0,
+                "recommended_strategies": ["momentum"],
+                "reason": "insufficient_data",
+            }
+
+        prices_arr = np.array(prices[-lb - 1:], dtype=float)
+        returns = np.diff(prices_arr) / prices_arr[:-1]
+
+        # 趨勢強度 = |平均收益| / 波動性
+        mean_return = np.mean(returns)
+        std_return = np.std(returns) if np.std(returns) > 0 else 1e-9
+        trend_strength = abs(mean_return) / std_return
+
+        # 波動性
+        volatility = float(std_return)
+
+        # 判定市場狀態
+        if trend_strength > self.config.trend_threshold:
+            if mean_return > 0:
+                regime = "trending_up"
+            else:
+                regime = "trending_down"
+        else:
+            regime = "sideways"
+
+        # 波動性修飾
+        if volatility > self.config.volatility_high:
+            vol_regime = "high_volatility"
+        elif volatility < self.config.volatility_low:
+            vol_regime = "low_volatility"
+        else:
+            vol_regime = "normal_volatility"
+
+        # 推薦策略
+        recommended = STRATEGY_MAP.get(regime, ["momentum"])
+
+        result = {
+            "regime": regime,
+            "volatility_regime": vol_regime,
+            "trend_strength": round(trend_strength, 4),
+            "mean_return": round(float(mean_return), 6),
+            "volatility": round(volatility, 6),
+            "recommended_strategies": recommended,
+        }
+
+        log.info(
+            f"Market Regime: {regime} (strength={trend_strength:.4f}, "
+            f"vol={volatility:.4%}) → {recommended}"
+        )
+
+        return result
+
+    def detect_with_adx(
+        self,
+        high: List[float],
+        low: List[float],
+        close: List[float],
+    ) -> Dict:
+        """
+        使用 ADX (Average Directional Index) 判定趨勢
+
+        ADX > 25 = 趨勢市
+        ADX < 25 = 震盪市
+        +DI > -DI = 上升趨勢
+        -DI > +DI = 下降趨勢
+        """
+        period = self.config.adx_period
+
+        if len(close) < period * 2:
+            return self.detect_regime(close)
+
+        h = np.array(high, dtype=float)
+        l = np.array(low, dtype=float)
+        c = np.array(close, dtype=float)
+
+        # True Range
+        tr_list = []
+        for i in range(1, len(c)):
+            tr = max(h[i] - l[i], abs(h[i] - c[i-1]), abs(l[i] - c[i-1]))
+            tr_list.append(tr)
+
+        # +DM, -DM
+        plus_dm = []
+        minus_dm = []
+        for i in range(1, len(c)):
+            up = h[i] - h[i-1]
+            down = l[i-1] - l[i]
+            plus_dm.append(up if up > down and up > 0 else 0)
+            minus_dm.append(down if down > up and down > 0 else 0)
+
+        # 平滑
+        tr_arr = np.array(tr_list, dtype=float)
+        pdm_arr = np.array(plus_dm, dtype=float)
+        mdm_arr = np.array(minus_dm, dtype=float)
+
+        atr = self._smooth(tr_arr, period)
+        smoothed_pdm = self._smooth(pdm_arr, period)
+        smoothed_mdm = self._smooth(mdm_arr, period)
+
+        # +DI, -DI
+        plus_di = 100 * smoothed_pdm / (atr + 1e-9)
+        minus_di = 100 * smoothed_mdm / (atr + 1e-9)
+
+        # DX, ADX
+        dx = 100 * np.abs(plus_di - minus_di) / (plus_di + minus_di + 1e-9)
+        adx = self._smooth(dx, period)
+
+        last_adx = float(adx[-1]) if len(adx) > 0 else 0
+        last_pdi = float(plus_di[-1]) if len(plus_di) > 0 else 0
+        last_mdi = float(minus_di[-1]) if len(minus_di) > 0 else 0
+
+        if last_adx > self.config.adx_trend_threshold:
+            if last_pdi > last_mdi:
+                regime = "trending_up"
+            else:
+                regime = "trending_down"
+        else:
+            regime = "sideways"
+
+        recommended = STRATEGY_MAP.get(regime, ["momentum"])
+
+        return {
+            "regime": regime,
+            "adx": round(last_adx, 2),
+            "plus_di": round(last_pdi, 2),
+            "minus_di": round(last_mdi, 2),
+            "recommended_strategies": recommended,
+        }
+
+    def select_strategy(self, regime: str) -> List[str]:
+        """根據市場狀態選擇策略"""
+        return STRATEGY_MAP.get(regime, ["momentum"])
+
+    @staticmethod
+    def _smooth(data: np.ndarray, period: int) -> np.ndarray:
+        """Wilder 平滑法"""
+        if len(data) < period:
+            return data
+        result = np.zeros_like(data)
+        result[period - 1] = np.sum(data[:period])
+        for i in range(period, len(data)):
+            result[i] = result[i - 1] - result[i - 1] / period + data[i]
+        return result[period - 1:]

--- a/v36/performance_metrics.py
+++ b/v36/performance_metrics.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+V3.6 — 績效評估指標 (根據第二/三章)
+=======================================
+關鍵指標:
+1. Sharpe Ratio     — 風險調整收益
+2. Information Ratio — 相對基準超額收益
+3. Calmar Ratio     — 收益 / 最大回撤
+4. Sortino Ratio    — 只考慮下行波動
+5. Win Rate         — 勝率
+6. Profit Factor    — 盈虧比
+7. Max Drawdown     — 最大回撤
+
+上線前必須通過:
+1. Sharpe Ratio > 1.0
+2. 最大回撤 < 15%
+3. 交易成本影響 < 20% 收益
+4. 樣本外測試通過
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import numpy as np
+
+log = logging.getLogger("V36.Perf")
+
+
+@dataclass
+class PerformanceThresholds:
+    """績效門檻 (上線前必須通過)"""
+    min_sharpe: float = 1.0
+    max_drawdown: float = 0.15
+    max_cost_impact: float = 0.20       # 成本佔收益 < 20%
+    min_profit_factor: float = 1.2
+    min_win_rate: float = 0.45
+    min_trades: int = 50                # 最少交易次數
+    risk_free_rate: float = 0.04        # 無風險利率 (年化 4%)
+
+
+class PerformanceMetrics:
+    """
+    策略績效評估
+
+    根據 Ernest Chan 書籍建議的關鍵指標
+    """
+
+    def __init__(self, thresholds: Optional[PerformanceThresholds] = None):
+        self.thresholds = thresholds or PerformanceThresholds()
+
+    def calculate_all_metrics(
+        self,
+        returns: List[float],
+        benchmark_returns: Optional[List[float]] = None,
+        risk_free_rate: Optional[float] = None,
+    ) -> Dict:
+        """
+        計算所有績效指標
+
+        參數:
+        - returns: 日收益率列表
+        - benchmark_returns: 基準收益率 (用於 IR)
+        - risk_free_rate: 無風險利率 (年化)
+
+        返回:
+        - dict: 所有績效指標
+        """
+        if not returns or len(returns) < 5:
+            return self._empty_metrics("insufficient_data")
+
+        rfr = risk_free_rate if risk_free_rate is not None else self.thresholds.risk_free_rate
+        ret = np.array(returns, dtype=float)
+
+        # 過濾 NaN 和 Inf
+        ret = ret[np.isfinite(ret)]
+        if len(ret) < 5:
+            return self._empty_metrics("too_many_nan")
+
+        # ─── 1. 基礎統計 ───
+        total_return = float(np.prod(1 + ret) - 1)
+        annual_return = float(np.mean(ret) * 252)
+        annual_volatility = float(np.std(ret, ddof=1) * np.sqrt(252))
+
+        # ─── 2. Sharpe Ratio ───
+        daily_rf = rfr / 252
+        excess_returns = ret - daily_rf
+        sharpe = float(np.mean(excess_returns) / np.std(excess_returns, ddof=1) * np.sqrt(252)) \
+            if np.std(excess_returns, ddof=1) > 0 else 0.0
+
+        # ─── 3. Information Ratio ───
+        info_ratio = None
+        if benchmark_returns is not None and len(benchmark_returns) == len(ret):
+            bench = np.array(benchmark_returns, dtype=float)
+            active_returns = ret - bench
+            active_std = np.std(active_returns, ddof=1)
+            info_ratio = float(np.mean(active_returns) / active_std * np.sqrt(252)) \
+                if active_std > 0 else 0.0
+
+        # ─── 4. Maximum Drawdown ───
+        equity = np.cumprod(1 + ret)
+        running_max = np.maximum.accumulate(equity)
+        drawdown = (equity - running_max) / running_max
+        max_dd = float(drawdown.min())
+
+        # ─── 5. Calmar Ratio ───
+        calmar = float(annual_return / abs(max_dd)) if max_dd != 0 else 0.0
+
+        # ─── 6. Sortino Ratio ───
+        downside_returns = ret[ret < 0]
+        downside_std = float(np.std(downside_returns, ddof=1)) if len(downside_returns) > 1 else 0.001
+        sortino = float(np.mean(excess_returns) / downside_std * np.sqrt(252)) \
+            if downside_std > 0 else 0.0
+
+        # ─── 7. Win Rate ───
+        win_trades = ret[ret > 0]
+        loss_trades = ret[ret < 0]
+        win_rate = float(len(win_trades) / len(ret)) if len(ret) > 0 else 0.0
+
+        # ─── 8. Profit Factor ───
+        avg_win = float(np.mean(win_trades)) if len(win_trades) > 0 else 0.0
+        avg_loss = float(abs(np.mean(loss_trades))) if len(loss_trades) > 0 else 0.001
+        profit_factor = float(avg_win / avg_loss) if avg_loss > 0 else 0.0
+
+        # ─── 9. 其他指標 ───
+        total_trades = len(ret)
+        max_consecutive_wins = self._max_consecutive(ret > 0)
+        max_consecutive_losses = self._max_consecutive(ret < 0)
+
+        metrics = {
+            "total_return": round(total_return, 6),
+            "annual_return": round(annual_return, 6),
+            "annual_volatility": round(annual_volatility, 6),
+            "sharpe_ratio": round(sharpe, 4),
+            "information_ratio": round(info_ratio, 4) if info_ratio is not None else None,
+            "calmar_ratio": round(calmar, 4),
+            "sortino_ratio": round(sortino, 4),
+            "max_drawdown": round(max_dd, 6),
+            "win_rate": round(win_rate, 4),
+            "avg_win": round(avg_win, 6),
+            "avg_loss": round(avg_loss, 6),
+            "profit_factor": round(profit_factor, 4),
+            "total_trades": total_trades,
+            "max_consecutive_wins": max_consecutive_wins,
+            "max_consecutive_losses": max_consecutive_losses,
+        }
+
+        return metrics
+
+    def validate_for_launch(
+        self,
+        metrics: Dict,
+        cost_impact: float = 0.0,
+    ) -> Dict:
+        """
+        上線前驗證
+
+        檢查所有績效是否達到門檻
+
+        返回:
+        - dict: {passed, checks, failed_checks}
+        """
+        checks = {}
+
+        # 1. Sharpe Ratio
+        sharpe = metrics.get("sharpe_ratio", 0)
+        checks["sharpe"] = {
+            "value": sharpe,
+            "threshold": self.thresholds.min_sharpe,
+            "passed": sharpe >= self.thresholds.min_sharpe,
+        }
+
+        # 2. Max Drawdown
+        max_dd = abs(metrics.get("max_drawdown", 0))
+        checks["max_drawdown"] = {
+            "value": max_dd,
+            "threshold": self.thresholds.max_drawdown,
+            "passed": max_dd <= self.thresholds.max_drawdown,
+        }
+
+        # 3. 成本影響
+        checks["cost_impact"] = {
+            "value": cost_impact,
+            "threshold": self.thresholds.max_cost_impact,
+            "passed": cost_impact <= self.thresholds.max_cost_impact,
+        }
+
+        # 4. Profit Factor
+        pf = metrics.get("profit_factor", 0)
+        checks["profit_factor"] = {
+            "value": pf,
+            "threshold": self.thresholds.min_profit_factor,
+            "passed": pf >= self.thresholds.min_profit_factor,
+        }
+
+        # 5. Win Rate
+        wr = metrics.get("win_rate", 0)
+        checks["win_rate"] = {
+            "value": wr,
+            "threshold": self.thresholds.min_win_rate,
+            "passed": wr >= self.thresholds.min_win_rate,
+        }
+
+        # 6. 交易次數
+        total = metrics.get("total_trades", 0)
+        checks["total_trades"] = {
+            "value": total,
+            "threshold": self.thresholds.min_trades,
+            "passed": total >= self.thresholds.min_trades,
+        }
+
+        failed = [k for k, v in checks.items() if not v["passed"]]
+        passed = len(failed) == 0
+
+        result = {
+            "passed": passed,
+            "checks": checks,
+            "failed_checks": failed,
+        }
+
+        if passed:
+            log.info("✅ 所有績效指標通過上線門檻")
+        else:
+            log.warning(f"⚠️ {len(failed)} 項未通過: {failed}")
+
+        return result
+
+    def format_report(self, metrics: Dict) -> str:
+        """格式化績效報告字符串"""
+        lines = [
+            "=" * 50,
+            "📊 V3.6 策略績效報告",
+            "=" * 50,
+            f"  總收益:         {metrics.get('total_return', 0):.2%}",
+            f"  年化收益:       {metrics.get('annual_return', 0):.2%}",
+            f"  年化波動:       {metrics.get('annual_volatility', 0):.2%}",
+            f"  Sharpe Ratio:   {metrics.get('sharpe_ratio', 0):.4f}",
+            f"  Sortino Ratio:  {metrics.get('sortino_ratio', 0):.4f}",
+            f"  Calmar Ratio:   {metrics.get('calmar_ratio', 0):.4f}",
+            f"  最大回撤:       {metrics.get('max_drawdown', 0):.2%}",
+            f"  勝率:           {metrics.get('win_rate', 0):.2%}",
+            f"  盈虧比:         {metrics.get('profit_factor', 0):.4f}",
+            f"  總交易次數:     {metrics.get('total_trades', 0)}",
+            f"  最大連勝:       {metrics.get('max_consecutive_wins', 0)}",
+            f"  最大連敗:       {metrics.get('max_consecutive_losses', 0)}",
+        ]
+        if metrics.get("information_ratio") is not None:
+            lines.append(f"  Information Ratio: {metrics['information_ratio']:.4f}")
+        lines.append("=" * 50)
+        return "\n".join(lines)
+
+    @staticmethod
+    def _max_consecutive(mask: np.ndarray) -> int:
+        """計算最大連續 True 次數"""
+        if len(mask) == 0:
+            return 0
+        max_count = 0
+        count = 0
+        for b in mask:
+            if b:
+                count += 1
+                max_count = max(max_count, count)
+            else:
+                count = 0
+        return max_count
+
+    @staticmethod
+    def _empty_metrics(reason: str) -> Dict:
+        return {
+            "total_return": 0.0,
+            "annual_return": 0.0,
+            "annual_volatility": 0.0,
+            "sharpe_ratio": 0.0,
+            "calmar_ratio": 0.0,
+            "sortino_ratio": 0.0,
+            "max_drawdown": 0.0,
+            "win_rate": 0.0,
+            "profit_factor": 0.0,
+            "total_trades": 0,
+            "reason": reason,
+        }

--- a/v36/risk_metrics.py
+++ b/v36/risk_metrics.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""
+V3.6 — 進階風險度量系統 (根據第六章)
+=======================================
+VaR (Value at Risk):
+  在 confidence_level 下的最大損失
+  例: VaR 95% = $1000 → 95% 概率下最大損失不超過 $1000
+
+CVaR (Conditional VaR / Expected Shortfall):
+  超過 VaR 的平均損失
+  即: 當損失超過 VaR 時，平均損失是多少
+
+最大回撤 (Maximum Drawdown):
+  從峰值到谷底的最大跌幅
+
+風險控制規則:
+- VaR 報警: 當日損失 > VaR 95% → 暫停交易
+- CVaR 報警: 損失 > CVaR 95% → 全面平倉
+- 最大回撤 > 15% → 停止新交易
+- 最大回撤 > 20% → 防守模式 (只平倉不開倉)
+- 最大回撤 > 30% → 策略暫停
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+log = logging.getLogger("V36.Risk")
+
+
+@dataclass
+class RiskControlConfig:
+    """風險控制配置"""
+    var_confidence: float = 0.95
+    var_stop_loss: bool = True          # VaR 觸發暫停
+    cvar_emergency_stop: bool = True    # CVaR 觸發全面平倉
+
+    # 最大回撤閾值
+    max_drawdown_stop: float = 0.15     # > 15% → 停止新交易
+    max_drawdown_pause: float = 0.20    # > 20% → 防守模式
+    max_drawdown_kill: float = 0.30     # > 30% → 策略暫停
+
+    # VaR 計算方法
+    var_method: str = "historical"      # "historical" / "parametric" / "monte_carlo"
+    var_lookback_days: int = 252         # 1 年
+
+
+class RiskMetrics:
+    """
+    進階風險度量
+
+    根據 Ernest Chan 書籍 第六章:
+    完整的風險度量系統 (VaR / CVaR / MDD)
+    """
+
+    def __init__(self, config: Optional[RiskControlConfig] = None):
+        self.config = config or RiskControlConfig()
+
+    def calculate_var(
+        self,
+        returns: List[float],
+        portfolio_value: float,
+        confidence_level: Optional[float] = None,
+    ) -> Dict:
+        """
+        VaR (Value at Risk) — 歷史模擬法
+
+        在 confidence_level 下的最大損失
+
+        返回:
+        - dict: {var_return, var_dollar, confidence, method}
+        """
+        if not returns or len(returns) < 10:
+            return {"var_return": 0.0, "var_dollar": 0.0, "confidence": 0.0, "method": "insufficient_data"}
+
+        confidence = confidence_level or self.config.var_confidence
+        returns_arr = np.array(returns, dtype=float)
+
+        if self.config.var_method == "parametric":
+            var_return = self._parametric_var(returns_arr, confidence)
+        else:
+            # 歷史模擬法
+            var_percentile = (1 - confidence) * 100
+            var_return = float(np.percentile(returns_arr, var_percentile))
+
+        var_dollar = portfolio_value * abs(var_return)
+
+        return {
+            "var_return": round(var_return, 6),
+            "var_dollar": round(var_dollar, 2),
+            "confidence": confidence,
+            "method": self.config.var_method,
+        }
+
+    def calculate_cvar(
+        self,
+        returns: List[float],
+        portfolio_value: float,
+        confidence_level: Optional[float] = None,
+    ) -> Dict:
+        """
+        CVaR (Conditional VaR / Expected Shortfall)
+
+        超過 VaR 的平均損失
+        """
+        if not returns or len(returns) < 10:
+            return {"cvar_return": 0.0, "cvar_dollar": 0.0}
+
+        confidence = confidence_level or self.config.var_confidence
+        returns_arr = np.array(returns, dtype=float)
+
+        var_percentile = (1 - confidence) * 100
+        var_return = float(np.percentile(returns_arr, var_percentile))
+
+        # 超過 VaR 的所有損失的平均值
+        tail_losses = returns_arr[returns_arr <= var_return]
+        if len(tail_losses) == 0:
+            cvar_return = var_return
+        else:
+            cvar_return = float(np.mean(tail_losses))
+
+        cvar_dollar = portfolio_value * abs(cvar_return)
+
+        return {
+            "cvar_return": round(cvar_return, 6),
+            "cvar_dollar": round(cvar_dollar, 2),
+            "confidence": confidence,
+        }
+
+    def calculate_max_drawdown(self, equity_curve: List[float]) -> Dict:
+        """
+        最大回撤 (Maximum Drawdown)
+
+        從峰值到谷底的最大跌幅
+
+        返回:
+        - dict: {max_drawdown, peak_idx, trough_idx, peak_value, trough_value, recovery_idx}
+        """
+        if not equity_curve or len(equity_curve) < 2:
+            return {"max_drawdown": 0.0}
+
+        equity = np.array(equity_curve, dtype=float)
+        running_max = np.maximum.accumulate(equity)
+        drawdown = (equity - running_max) / running_max
+
+        max_dd = float(drawdown.min())
+        trough_idx = int(np.argmin(drawdown))
+        peak_idx = int(np.argmax(equity[:trough_idx + 1])) if trough_idx > 0 else 0
+
+        # 找恢復點
+        recovery_idx = None
+        peak_value = float(equity[peak_idx])
+        for i in range(trough_idx + 1, len(equity)):
+            if equity[i] >= peak_value:
+                recovery_idx = i
+                break
+
+        return {
+            "max_drawdown": round(max_dd, 6),
+            "peak_idx": peak_idx,
+            "trough_idx": trough_idx,
+            "peak_value": round(peak_value, 2),
+            "trough_value": round(float(equity[trough_idx]), 2),
+            "recovery_idx": recovery_idx,
+            "drawdown_series": drawdown.tolist(),
+        }
+
+    def calculate_rolling_var(
+        self,
+        returns: List[float],
+        portfolio_value: float,
+        window: int = 60,
+    ) -> List[Dict]:
+        """
+        滾動 VaR 計算
+
+        每 window 期計算一次 VaR
+        """
+        if len(returns) < window:
+            return []
+
+        results = []
+        returns_arr = np.array(returns, dtype=float)
+
+        for i in range(window, len(returns_arr)):
+            window_returns = returns_arr[i - window:i]
+            var_result = self.calculate_var(window_returns.tolist(), portfolio_value)
+            var_result["index"] = i
+            results.append(var_result)
+
+        return results
+
+    def full_risk_report(
+        self,
+        returns: List[float],
+        equity_curve: List[float],
+        portfolio_value: float,
+    ) -> Dict:
+        """
+        完整風險報告
+
+        返回:
+        - dict: VaR + CVaR + MDD + 風險等級 + 建議動作
+        """
+        var_result = self.calculate_var(returns, portfolio_value)
+        cvar_result = self.calculate_cvar(returns, portfolio_value)
+        mdd_result = self.calculate_max_drawdown(equity_curve)
+
+        max_dd = abs(mdd_result.get("max_drawdown", 0))
+
+        # 風險等級判定
+        risk_level, action = self._determine_risk_level(max_dd)
+
+        report = {
+            "var": var_result,
+            "cvar": cvar_result,
+            "max_drawdown": mdd_result,
+            "risk_level": risk_level,
+            "action": action,
+            "portfolio_value": portfolio_value,
+        }
+
+        log.info(
+            f"Risk Report: VaR={var_result['var_dollar']:.2f} "
+            f"CVaR={cvar_result['cvar_dollar']:.2f} "
+            f"MDD={max_dd:.2%} → {risk_level} ({action})"
+        )
+
+        return report
+
+    def check_daily_risk(
+        self,
+        daily_pnl: float,
+        returns_history: List[float],
+        portfolio_value: float,
+    ) -> Dict:
+        """
+        每日風險檢查
+
+        返回:
+        - dict: {var_breached, cvar_breached, action}
+        """
+        var = self.calculate_var(returns_history, portfolio_value)
+        cvar = self.calculate_cvar(returns_history, portfolio_value)
+
+        daily_loss = abs(daily_pnl) if daily_pnl < 0 else 0
+
+        var_breached = daily_loss > var["var_dollar"] if var["var_dollar"] > 0 else False
+        cvar_breached = daily_loss > cvar["cvar_dollar"] if cvar["cvar_dollar"] > 0 else False
+
+        if cvar_breached and self.config.cvar_emergency_stop:
+            action = "EMERGENCY_LIQUIDATE"
+            log.critical(f"🚨 CVaR 突破! 損失 ${daily_loss:.2f} > CVaR ${cvar['cvar_dollar']:.2f}")
+        elif var_breached and self.config.var_stop_loss:
+            action = "PAUSE_TRADING"
+            log.warning(f"⚠️ VaR 突破! 損失 ${daily_loss:.2f} > VaR ${var['var_dollar']:.2f}")
+        else:
+            action = "CONTINUE"
+
+        return {
+            "daily_pnl": daily_pnl,
+            "daily_loss": daily_loss,
+            "var": var,
+            "cvar": cvar,
+            "var_breached": var_breached,
+            "cvar_breached": cvar_breached,
+            "action": action,
+        }
+
+    def _determine_risk_level(self, max_dd: float) -> Tuple[str, str]:
+        """根據最大回撤判定風險等級"""
+        if max_dd >= self.config.max_drawdown_kill:
+            return "CRITICAL", "STRATEGY_PAUSE"
+        elif max_dd >= self.config.max_drawdown_pause:
+            return "HIGH", "DEFENSE_MODE"
+        elif max_dd >= self.config.max_drawdown_stop:
+            return "ELEVATED", "STOP_NEW_TRADES"
+        elif max_dd >= 0.10:
+            return "MODERATE", "REDUCE_POSITION"
+        else:
+            return "NORMAL", "CONTINUE"
+
+    @staticmethod
+    def _parametric_var(returns: np.ndarray, confidence: float) -> float:
+        """參數化 VaR (假設正態分佈)"""
+        from scipy import stats
+        mean = np.mean(returns)
+        std = np.std(returns)
+        z_score = stats.norm.ppf(1 - confidence)
+        return float(mean + z_score * std)

--- a/v36/strategy_config.py
+++ b/v36/strategy_config.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+V3.6 — 完整策略配置 (第七部分)
+===================================
+集中管理所有 V3.6 模組配置
+
+配置包含:
+- money_management: Kelly 資金管理
+- transaction_costs: 交易成本
+- risk_management: 風險控制
+- strategies: 策略參數
+- backtest: 回測設定
+- symbols: 股票池
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field, asdict
+from typing import Dict, List, Optional
+
+log = logging.getLogger("V36.Config")
+
+
+@dataclass
+class V36Config:
+    """V3.6 完整策略配置"""
+
+    strategy_version: str = "3.6"
+
+    # ─── 資金管理 ───
+    kelly_factor: float = 0.5
+    max_position_per_trade: float = 0.15
+    max_total_position: float = 0.80
+    max_positions: int = 10
+    risk_per_trade: float = 0.02
+    max_daily_risk: float = 0.05
+
+    # ─── 交易成本 ───
+    commission_rate: float = 0.001
+    slippage_large_cap: float = 0.0005
+    slippage_mid_cap: float = 0.001
+    slippage_small_cap: float = 0.002
+    min_cost_threshold: float = 0.001
+
+    # ─── 風險管理 ───
+    var_confidence: float = 0.95
+    var_stop_loss: bool = True
+    max_drawdown_stop: float = 0.15
+    max_drawdown_pause: float = 0.20
+    max_drawdown_kill: float = 0.30
+
+    # ─── 均值回歸策略 ───
+    mean_reversion_enabled: bool = True
+    rsi_oversold: int = 30
+    rsi_overbought: int = 70
+    rsi_lookback: int = 14
+
+    # ─── 動量策略 ───
+    momentum_enabled: bool = True
+    macd_fast: int = 12
+    macd_slow: int = 26
+    macd_signal: int = 9
+
+    # ─── 突破策略 ───
+    breakout_enabled: bool = False
+    breakout_lookback: int = 20
+    breakout_volume_threshold: float = 1.5
+
+    # ─── 回測 ───
+    train_test_split: float = 0.7
+    walk_forward: bool = True
+    cost_included: bool = True
+
+    # ─── 股票池 ───
+    symbols_us: List[str] = field(
+        default_factory=lambda: ["NVDA", "TSLA", "AMD", "META", "GOOGL"]
+    )
+    symbols_hk: List[str] = field(
+        default_factory=lambda: ["0700.HK", "9988.HK", "3690.HK"]
+    )
+
+    def to_dict(self) -> Dict:
+        """轉換為字典"""
+        return asdict(self)
+
+    def to_json(self, indent: int = 2) -> str:
+        """轉換為 JSON 字符串"""
+        return json.dumps(self.to_dict(), indent=indent, ensure_ascii=False)
+
+    def save(self, filepath: str) -> None:
+        """保存配置到文件"""
+        with open(filepath, "w", encoding="utf-8") as f:
+            f.write(self.to_json())
+        log.info(f"V3.6 config saved to {filepath}")
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "V36Config":
+        """從字典創建配置"""
+        valid_fields = {f.name for f in cls.__dataclass_fields__.values()}
+        filtered = {k: v for k, v in data.items() if k in valid_fields}
+        return cls(**filtered)
+
+    @classmethod
+    def from_json(cls, filepath: str) -> "V36Config":
+        """從 JSON 文件載入配置"""
+        with open(filepath, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        # 支援嵌套格式 (V3.6_STRATEGY_DESIGN.md 中的配置格式)
+        flat = {}
+        if "money_management" in data:
+            flat.update(data["money_management"])
+        if "transaction_costs" in data:
+            flat.update(data["transaction_costs"])
+        if "risk_management" in data:
+            flat.update(data["risk_management"])
+        if "strategies" in data:
+            for strat_name, strat_cfg in data["strategies"].items():
+                if strat_name == "mean_reversion":
+                    flat["mean_reversion_enabled"] = strat_cfg.get("enabled", True)
+                    flat["rsi_oversold"] = strat_cfg.get("rsi_oversold", 30)
+                    flat["rsi_overbought"] = strat_cfg.get("rsi_overbought", 70)
+                    flat["rsi_lookback"] = strat_cfg.get("lookback_period", 14)
+                elif strat_name == "momentum":
+                    flat["momentum_enabled"] = strat_cfg.get("enabled", True)
+                    flat["macd_fast"] = strat_cfg.get("macd_fast", 12)
+                    flat["macd_slow"] = strat_cfg.get("macd_slow", 26)
+                    flat["macd_signal"] = strat_cfg.get("macd_signal", 9)
+                elif strat_name == "breakout":
+                    flat["breakout_enabled"] = strat_cfg.get("enabled", False)
+                    flat["breakout_lookback"] = strat_cfg.get("lookback_period", 20)
+                    flat["breakout_volume_threshold"] = strat_cfg.get("volume_threshold", 1.5)
+        if "backtest" in data:
+            flat.update(data["backtest"])
+        if "symbols" in data:
+            if "US" in data["symbols"]:
+                flat["symbols_us"] = data["symbols"]["US"]
+            if "HK" in data["symbols"]:
+                flat["symbols_hk"] = data["symbols"]["HK"]
+
+        # 如果是扁平格式，直接使用
+        if not flat:
+            flat = data
+
+        return cls.from_dict(flat)
+
+
+def load_v36_config(config_path: Optional[str] = None) -> V36Config:
+    """
+    載入 V3.6 配置
+
+    優先順序:
+    1. 傳入的 config_path
+    2. 環境變數 V36_CONFIG_PATH
+    3. 同目錄下的 v36_config.json
+    4. 默認配置
+    """
+    paths_to_try = []
+
+    if config_path:
+        paths_to_try.append(config_path)
+
+    env_path = os.environ.get("V36_CONFIG_PATH")
+    if env_path:
+        paths_to_try.append(env_path)
+
+    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    paths_to_try.append(os.path.join(base_dir, "v36_config.json"))
+
+    for path in paths_to_try:
+        if os.path.exists(path):
+            log.info(f"Loading V3.6 config from {path}")
+            return V36Config.from_json(path)
+
+    log.info("Using default V3.6 config")
+    return V36Config()

--- a/v36/transaction_cost.py
+++ b/v36/transaction_cost.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+V3.6 — 交易成本模型 (根據第三章)
+===================================
+根據書籍建議：真實交易成本必須計入回測
+
+成本組成:
+1. 佣金 (Commission)
+2. 滑點 (Slippage)
+3. 印花稅 (Stamp Duty, HK only)
+
+成本門檻檢查:
+- 預期收益 < 成本比率 → 不執行
+- 回測必須使用成本後淨收益
+- 建議成本緩衝: +20%
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+log = logging.getLogger("V36.Cost")
+
+
+@dataclass
+class CostConfig:
+    """交易成本配置"""
+    # 佣金率
+    us_stock_commission: float = 0.001     # 美股 0.1%
+    hk_stock_commission: float = 0.001     # 港股 0.1%
+    futures_commission: float = 0.0002     # 期貨 0.02%
+
+    # HK 印花稅
+    hk_stamp_duty: float = 0.001           # 0.1%
+
+    # 滑點模型
+    slippage_large_cap: float = 0.0005     # 大型股 0.05%
+    slippage_mid_cap: float = 0.001        # 中型股 0.1%
+    slippage_small_cap: float = 0.002      # 小型股 0.2%
+
+    # 最低成本門檻 (如策略預期收益低於此比率 → 不交易)
+    min_cost_threshold: float = 0.001      # 0.1%
+
+    # 成本緩衝 (預防市場條件變化)
+    cost_buffer_pct: float = 0.20          # +20%
+
+    # 最低佣金 (USD)
+    min_commission_usd: float = 1.0
+
+
+class TransactionCostCalculator:
+    """
+    交易成本計算器
+
+    根據 Ernest Chan 書籍 第三章:
+    Real trading costs MUST be included in backtesting.
+    """
+
+    def __init__(self, config: Optional[CostConfig] = None):
+        self.config = config or CostConfig()
+
+    def calculate_total_cost(
+        self,
+        symbol: str,
+        quantity: int,
+        price: float,
+        market_cap: str = "large_cap",
+        side: str = "BUY",
+    ) -> Dict:
+        """
+        計算總交易成本
+
+        參數:
+        - symbol: 股票代碼
+        - quantity: 數量
+        - price: 價格
+        - market_cap: 市值類型 (large_cap / mid_cap / small_cap)
+        - side: BUY / SELL
+
+        返回:
+        - dict: 成本明細
+        """
+        if quantity <= 0 or price <= 0:
+            return {
+                "commission": 0.0,
+                "slippage": 0.0,
+                "stamp_duty": 0.0,
+                "total_cost": 0.0,
+                "cost_rate": 0.0,
+                "effective_price": price,
+                "cost_with_buffer": 0.0,
+            }
+
+        trade_value = quantity * price
+
+        # 1. 佣金
+        if self._is_hk_stock(symbol):
+            commission = max(
+                trade_value * self.config.hk_stock_commission,
+                self.config.min_commission_usd
+            )
+            stamp_duty = trade_value * self.config.hk_stamp_duty
+        elif self._is_futures(symbol):
+            commission = trade_value * self.config.futures_commission
+            stamp_duty = 0.0
+        else:
+            # 默認美股
+            commission = max(
+                trade_value * self.config.us_stock_commission,
+                self.config.min_commission_usd
+            )
+            stamp_duty = 0.0
+
+        # 2. 滑點
+        slippage_rate = {
+            "large_cap": self.config.slippage_large_cap,
+            "mid_cap": self.config.slippage_mid_cap,
+            "small_cap": self.config.slippage_small_cap,
+        }.get(market_cap, self.config.slippage_mid_cap)
+
+        slippage = trade_value * slippage_rate
+
+        # 3. 總成本
+        total_cost = commission + slippage + stamp_duty
+        cost_rate = total_cost / trade_value if trade_value > 0 else 0.0
+        cost_with_buffer = total_cost * (1 + self.config.cost_buffer_pct)
+
+        # 4. 有效價格
+        if side == "BUY":
+            effective_price = price * (1 + cost_rate)
+        else:
+            effective_price = price * (1 - cost_rate)
+
+        result = {
+            "commission": round(commission, 4),
+            "slippage": round(slippage, 4),
+            "stamp_duty": round(stamp_duty, 4),
+            "total_cost": round(total_cost, 4),
+            "cost_rate": round(cost_rate, 6),
+            "effective_price": round(effective_price, 4),
+            "cost_with_buffer": round(cost_with_buffer, 4),
+            "trade_value": round(trade_value, 2),
+        }
+
+        log.debug(
+            f"Cost [{symbol}] {side} {quantity}@${price:.2f}: "
+            f"total=${total_cost:.4f} ({cost_rate:.4%})"
+        )
+
+        return result
+
+    def is_profitable_after_cost(
+        self,
+        expected_return: float,
+        symbol: str,
+        quantity: int,
+        price: float,
+        market_cap: str = "large_cap",
+    ) -> Dict:
+        """
+        檢查策略在交易成本後是否仍然有利可圖
+
+        參數:
+        - expected_return: 預期收益率
+        - symbol, quantity, price, market_cap: 交易參數
+
+        返回:
+        - dict: {profitable, expected_net_return, round_trip_cost_rate}
+        """
+        buy_cost = self.calculate_total_cost(symbol, quantity, price, market_cap, "BUY")
+        sell_cost = self.calculate_total_cost(symbol, quantity, price, market_cap, "SELL")
+
+        # 來回成本
+        round_trip_cost_rate = buy_cost["cost_rate"] + sell_cost["cost_rate"]
+        round_trip_cost_with_buffer = round_trip_cost_rate * (1 + self.config.cost_buffer_pct)
+
+        net_return = expected_return - round_trip_cost_with_buffer
+        profitable = net_return > self.config.min_cost_threshold
+
+        result = {
+            "profitable": profitable,
+            "expected_return": expected_return,
+            "round_trip_cost_rate": round(round_trip_cost_rate, 6),
+            "round_trip_cost_with_buffer": round(round_trip_cost_with_buffer, 6),
+            "expected_net_return": round(net_return, 6),
+        }
+
+        if not profitable:
+            log.warning(
+                f"⚠️ [{symbol}] 預期收益 ({expected_return:.4%}) < "
+                f"成本+緩衝 ({round_trip_cost_with_buffer:.4%}) → 不建議交易"
+            )
+
+        return result
+
+    def apply_cost_to_returns(
+        self,
+        gross_returns: list,
+        symbol: str,
+        quantity: int = 100,
+        price: float = 100.0,
+        market_cap: str = "large_cap",
+    ) -> list:
+        """
+        將交易成本應用到回測收益序列
+
+        gross_returns: 毛收益列表
+        返回: 淨收益列表
+        """
+        cost = self.calculate_total_cost(symbol, quantity, price, market_cap)
+        cost_per_trade = cost["cost_rate"]
+
+        net_returns = []
+        for r in gross_returns:
+            if r != 0:
+                # 每次交易扣除成本
+                net_r = r - cost_per_trade
+            else:
+                net_r = r
+            net_returns.append(net_r)
+
+        return net_returns
+
+    @staticmethod
+    def _is_hk_stock(symbol: str) -> bool:
+        return symbol.endswith(".HK") or symbol.startswith("HK.")
+
+    @staticmethod
+    def _is_futures(symbol: str) -> bool:
+        futures_suffixes = (".FUT", ".F", "/ES", "/NQ", "/CL")
+        return any(symbol.endswith(s) for s in futures_suffixes)

--- a/v36_config.json
+++ b/v36_config.json
@@ -1,0 +1,59 @@
+{
+  "strategy_version": "3.6",
+
+  "money_management": {
+    "kelly_factor": 0.5,
+    "max_position_per_trade": 0.15,
+    "max_total_position": 0.80,
+    "max_positions": 10,
+    "risk_per_trade": 0.02,
+    "max_daily_risk": 0.05
+  },
+
+  "transaction_costs": {
+    "commission_rate": 0.001,
+    "slippage_large_cap": 0.0005,
+    "slippage_mid_cap": 0.001,
+    "slippage_small_cap": 0.002,
+    "min_cost_threshold": 0.001
+  },
+
+  "risk_management": {
+    "var_confidence": 0.95,
+    "var_stop_loss": true,
+    "max_drawdown_stop": 0.15,
+    "max_drawdown_pause": 0.20,
+    "max_drawdown_kill": 0.30
+  },
+
+  "strategies": {
+    "mean_reversion": {
+      "enabled": true,
+      "rsi_oversold": 30,
+      "rsi_overbought": 70,
+      "lookback_period": 14
+    },
+    "momentum": {
+      "enabled": true,
+      "macd_fast": 12,
+      "macd_slow": 26,
+      "macd_signal": 9
+    },
+    "breakout": {
+      "enabled": false,
+      "lookback_period": 20,
+      "volume_threshold": 1.5
+    }
+  },
+
+  "backtest": {
+    "train_test_split": 0.7,
+    "walk_forward": true,
+    "cost_included": true
+  },
+
+  "symbols": {
+    "US": ["NVDA", "TSLA", "AMD", "META", "GOOGL"],
+    "HK": ["0700.HK", "9988.HK", "3690.HK"]
+  }
+}


### PR DESCRIPTION
##  概覽

根據《量化交易：如何建立自己的演算法交易業務》Ernest Chan 書籍，實施 V3.6 全新策略架構。

##  新增模組 (v36/)

| 模組 | 功能 | 對應章節 |
|------|------|---------|
| kelly_position_sizer.py | Kelly Formula 動態倉位 | 第六章 |
| 	ransaction_cost.py | 交易成本計算 + 可行性門檻 | 第三章 |
| isk_metrics.py | VaR / CVaR / 最大回撤 | 第六章 |
| performance_metrics.py | Sharpe / Sortino / Calmar / IR | 第二/三章 |
| market_regime.py | 市場狀態識別 + 自動策略選擇 | 第七章 |
| acktest_engine.py | 無偏差回測 + Walk-Forward | 第三章 |
| strategy_config.py | 統一配置管理 | - |

##  整合變更

- **isk_guard_v36.py**: 升級版風控，整合 Kelly + 成本門檻 + VaR 日風險
- **execution_engine.py**: 切換至 RiskGuardV36
- **36_config.json**: V3.6 默認配置

##  測試

- 	ests/test_v36.py: **6 個單元測試，全部通過** 

## 風險鐵律



Closes #V3.6_STRATEGY_DESIGN