### PR TITLE
fix: daily code review — 修復 7 個系統缺陷

### DIFF
--- a/config.py
+++ b/config.py
@@ -49,7 +49,7 @@ def _detect_opend_host() -> str:
 # Infoway & Data Priority Config
 # ============================================================
 INFOWAY_CONFIG = {
-    "API_KEY": "9d122d7ab6fd4965bb45e28e9cf00435",
+    "API_KEY": os.environ.get("INFOWAY_API_KEY", ""),
     "WS_URL": "wss://data.infoway.io/ws?business=stock",
 }
 DATA_PRIORITY = ["INFOWAY", "FUTU", "MASSIVE", "YFINANCE"]
@@ -179,7 +179,7 @@ DATA_DIR   = os.path.join(BASE_DIR, "data")      # Market data
 BACKUP_DIR = os.path.join(BASE_DIR, "backups")    # System backups
 
 # Daily trading output (paper trading records, PnL reports)
-DAILY_DIR  = "/home/tsukii0607/.openclaw/workspace/kiro_quant_daily"
+DAILY_DIR  = os.environ.get("KIRO_DAILY_DIR", os.path.join(BASE_DIR, "daily"))
 
 # ============================================================
 # Helper

--- a/execution_engine.py
+++ b/execution_engine.py
@@ -14,6 +14,7 @@ import logging
 import time
 import state_store as ss
 from risk_guard_v36 import RiskGuardV36
+from notifier import send_tg_msg
 from config import (
     OPEND_HOST, OPEND_PORT, TRADE_PWD, TRADE_MODE, MARKET, ORDER_COOLDOWN_HOURS,
     EMERGENCY_DAILY_LOSS_PCT, MIN_TOTAL_ASSETS_ALERT
@@ -408,11 +409,9 @@ class ExecutionEngine:
             last = state.get("last_orders", {}).get(code, {})
             last_signal = last.get("signal", "")
             last_time = last.get("time", 0)
-            import time as _time
-            # 同一交易日內已有 BUY 紀錄 → 跳過（冷卻時間可配置，默認 1 小時）
             cooldown_secs = ORDER_COOLDOWN_HOURS * 3600
-            if last_signal == "BUY" and (_time.time() - last_time) < cooldown_secs:
-                log.info(f"⏸ {code} 今日已下 BUY（{int((_time.time()-last_time)/60)} 分鐘前），等待成交確認")
+            if last_signal == "BUY" and (time.time() - last_time) < cooldown_secs:
+                log.info(f"⏸ {code} 今日已下 BUY（{int((time.time()-last_time)/60)} 分鐘前），等待成交確認")
                 return {"status": "SKIP", "reason": "OrderPending"}
 
         # 3. 風控檢查

--- a/state_store.py
+++ b/state_store.py
@@ -9,6 +9,7 @@ Quant Engine v2 - State Store
 """
 
 import json
+import os
 import time
 import logging
 import hashlib
@@ -91,7 +92,6 @@ def save(state: dict):
     tmp_path = f"{STATE_PATH}.tmp"
     with open(tmp_path, "w", encoding="utf-8") as f:
         json.dump(state, f, indent=2, ensure_ascii=False)
-    import os
     os.replace(tmp_path, STATE_PATH)
 
 

--- a/v3_collector.py
+++ b/v3_collector.py
@@ -88,8 +88,11 @@ class DataCollector:
                 to_fetch_new.append(sym)
                 continue
             
-            # Simple check: if less than X days of data, it might have a gap or be incomplete
-            # (Note: This is a heuristic. A more complex check would look for interior date gaps)
+            if not stats["end"]:
+                logger.info(f"Target [{sym}]: No end timestamp. Adding to repair.")
+                to_repair_gap.append(sym)
+                continue
+
             last_date = datetime.strptime(stats["end"].split(".")[0], "%Y-%m-%d %H:%M:%S")
             days_old = (datetime.now() - last_date).days
             

--- a/v3_launcher.py
+++ b/v3_launcher.py
@@ -144,7 +144,7 @@ def resolve_runtime_profile(config_path: str = "config.json", override: Optional
     return RUNTIME_PROFILES["lite"]
 
 
-def run_kiro_v35(config_path: str = "config.json", profile_override: Optional[str] = None, dry_run: bool = False) -> None:
+def run_kiro_v36(config_path: str = "config.json", profile_override: Optional[str] = None, dry_run: bool = False) -> None:
     live_cfg_data = build_live_config(config_path)
     profile = resolve_runtime_profile(config_path=config_path, override=profile_override)
 
@@ -201,4 +201,4 @@ if __name__ == "__main__":
     parser.add_argument("--profile", choices=sorted(RUNTIME_PROFILES.keys()), help="Runtime profile override")
     parser.add_argument("--dry-run", action="store_true", help="Print resolved runtime and exit")
     args = parser.parse_args()
-    run_kiro_v35(config_path=args.config, profile_override=args.profile, dry_run=args.dry_run)
+    run_kiro_v36(config_path=args.config, profile_override=args.profile, dry_run=args.dry_run)


### PR DESCRIPTION
- execution_engine: 補上缺失的 send_tg_msg import（原本所有訂單通知會 NameError）
- execution_engine: 移除 execute() 內的重複 import time as _time，統一用頂層 time
- state_store: 將 os import 移至模組頂層（原在 save() 內部延遲 import）
- config: INFOWAY_CONFIG API_KEY 改用 env var INFOWAY_API_KEY，移除硬編碼金鑰
- config: DAILY_DIR 改用 env var KIRO_DAILY_DIR 或 BASE_DIR/daily，移除機器特定絕對路徑
- v3_collector: smart_repair 加入 stats['end'] None 檢查，防止 strptime crash
- v3_launcher: run_kiro_v35 → run_kiro_v36，函式名與系統版本一致

https://claude.ai/code/session_013NoGn1Y55XjvTQb95rcWDx