### PR TITLE
Fix model loading with registry-based resolution and auto-rebuild

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,11 +1,14 @@
 {
   "auto_trade": true,
-  "paper_trading": true,
-  "market": "HK",
-  "data_source_preference": [
-    "yfinance"
-  ],
-  "rate_limit_delay": 1.1,
+  "paper_trading": false,
+  "model": {
+    "input_dim": 26,
+    "markets": {
+      "HK": "v3_hk_stocks",
+      "US": "v3_us_stocks",
+      "IDLE": "v3_us_stocks"
+    }
+  },
   "v3_live": {
     "symbols_list": [
       "AAPL",
@@ -60,32 +63,64 @@
       "KO"
     ],
     "prediction_thresholds": {
-      "0700.HK": 0.01,
-      "9988.HK": 0.01,
-      "3690.HK": 0.01,
-      "1024.HK": 0.01,
-      "2318.HK": 0.01,
-      "1299.HK": 0.01,
-      "0939.HK": 0.01,
-      "0005.HK": 0.01,
-      "0388.HK": 0.01,
-      "0960.HK": 0.01,
-      "1109.HK": 0.01,
-      "0941.HK": 0.01,
-      "0175.HK": 0.01,
-      "1810.HK": 0.01,
-      "2688.HK": 0.01,
-      "2269.HK": 0.01,
-      "1211.HK": 0.01,
-      "2018.HK": 0.01,
-      "0688.HK": 0.01
+      "0700.HK": 0.007000000000000002,
+      "9988.HK": 0.007000000000000002,
+      "3690.HK": 0.007000000000000002
     },
-    "buy_cooldown_cycles": 3,
+    "buy_cooldown_cycles": 4,
+    "swing_buy_confirmation_count": 2,
+    "swing_block_on_model_sell": false,
     "polling_seconds": 60,
     "auto_trade": true,
-    "paper_trading": true,
-    "stop_loss_pct": 0.03,
-    "quick_take_profit_pct": 0.06,
-    "max_positions": 10
-  }
+    "paper_trading": false,
+    "stop_loss_pct": 0.02,
+    "quick_take_profit_pct": 0.02,
+    "max_hold_bars": 30,
+    "max_positions": 15,
+    "market_mode": "AUTO",
+    "rsi_oversold": 38,
+    "rsi_overbought": 79,
+    "macd_signal": 0.005,
+    "xgb_confidence": 0.1,
+    "min_hold_minutes": 45,
+    "time_exit_near_entry_pct": 0.005,
+    "rsi_extreme_oversold": 35,
+    "bb_position_threshold": 0.2,
+    "vix_dynamic_confidence_enabled": true,
+    "capital_buckets": {
+      "fractions": {
+        "long": 0.5,
+        "mid": 0.3,
+        "short": 0.1,
+        "reserve": 0.1,
+        "avoid": 0
+      },
+      "thresholds": {
+        "long": 0.002,
+        "mid": 0.0015,
+        "short": 0.0012,
+        "avoid": 0.01
+      },
+      "by_symbol": {}
+    },
+    "short_enabled": true,
+    "rsi_deep_overbought": 80,
+    "macd_negative_required": true,
+    "sma_filter_short": true,
+    "short_min_confidence_threshold": 0.1,
+    "short_sentiment_max": 0.1,
+    "short_stop_loss": 0.015,
+    "short_take_profit": 0.02,
+    "short_trailing_stop_trigger": 0.015,
+    "short_trailing_stop_lock": 0
+  },
+  "futu": {
+    "target_acc_id": 18526451,
+    "host": "127.0.0.1",
+    "port": 11112,
+    "trd_env": "SIMULATE"
+  },
+  "posture": "risk_on",
+  "posture_timestamp": "2026-05-05T15:34:10.517912",
+  "posture_rationale": "2800.HK momentum: 0.0015, 3033.HK momentum: 0.0029. Posture determined as risk_on."
 }

--- a/v3_launcher.py
+++ b/v3_launcher.py
@@ -307,44 +307,89 @@ def _ensure_symbol_state(loop: "LiveTradingLoop", symbol: str) -> None:
     )
 
 
-def _load_market_model(loop: "LiveTradingLoop", mode: str) -> None:
-    """Load the appropriate model for the current market mode."""
-    model_name = "v3_us_stocks"
-    if mode == "HK":
-        model_name = "v3_hk_stocks"
-    
+_DEFAULT_MARKET_MODELS = {
+    "HK": "v3_hk_stocks",
+    "US": "v3_us_stocks",
+    "IDLE": "v3_us_stocks",
+}
+
+
+def _model_name_for_market(mode: str, config_path: str = "config.json") -> str:
+    """Resolve the logical model name for ``mode`` from config, with a default."""
+    cfg, _ = _read_config(config_path)
+    markets = (cfg.get("model") or {}).get("markets") or {}
+    return str(markets.get(mode) or _DEFAULT_MARKET_MODELS.get(mode, "v3_us_stocks"))
+
+
+def _load_market_model(loop: "LiveTradingLoop", mode: str, config_path: str = "config.json") -> None:
+    """Load the appropriate model for the current market mode.
+
+    Resolution chain (first success wins):
+        1. config.json -> model.markets[mode]
+        2. Built-in default (HK -> v3_hk_stocks, US/IDLE -> v3_us_stocks)
+        3. Sibling market's model (HK falls through to US, and vice versa)
+        4. Registry default in models_registry.json
+
+    Steps 1–3 produce a logical name; the ModelManager / ModelRegistry then
+    resolves that to an actual checkpoint file via aliases. This means the
+    user can swap models by editing config.json or models_registry.json
+    without touching code.
+    """
+    primary = _model_name_for_market(mode, config_path)
+    fallback_mode = "US" if mode == "HK" else "HK" if mode == "US" else None
+    fallback = _model_name_for_market(fallback_mode, config_path) if fallback_mode else None
+
+    candidates = [primary] + ([fallback] if fallback and fallback != primary else [])
+
+    last_exc: Optional[Exception] = None
+    for name in candidates:
+        try:
+            loop.logger.info("Switching model for market %s: %s", mode, name)
+            loop.model_manager.load(name)
+            if name != primary:
+                loop.logger.info("Loaded fallback model %s for market %s", name, mode)
+            return
+        except Exception as exc:
+            last_exc = exc
+            loop.logger.warning("Failed to load model %s for market %s: %s", name, mode, exc)
+
+    loop.logger.error(
+        "No usable model for market %s after trying %s; continuing without weights. Last error: %s",
+        mode, candidates, last_exc,
+    )
+
+
+def _safe_connector_connect(connector, symbols: list[str] | None = None) -> None:
+    """Connector compatibility shim for old/new FutuConnector signatures."""
     try:
-        loop.logger.info("Switching model for market %s: %s", mode, model_name)
-        loop.model_manager.load(model_name)
-    except Exception as exc:
-        loop.logger.warning("Failed to load model %s for market %s: %s", model_name, mode, exc)
-        # Fallback to US model if HK missing
-        if mode == "HK" and model_name != "v3_us_stocks":
-            try:
-                loop.model_manager.load("v3_us_stocks")
-                loop.logger.info("Fallback to v3_us_stocks for HK market")
-            except Exception:
-                pass
+        if symbols is not None:
+            connector.connect(symbols=symbols)
+        else:
+            connector.connect()
+    except TypeError:
+        connector.connect()
 
 
-async def _apply_market_mode(loop: "LiveTradingLoop", base_cfg: "LiveConfig", mode: str, prev_mode: str | None) -> None:
+async def _apply_market_mode(loop: "LiveTradingLoop", base_cfg: "LiveConfig", mode: str, prev_mode: str | None, config_path: str = "config.json") -> None:
     symbols = _symbols_for_mode(mode)
     auto_trade = mode in {"HK", "US"} and base_cfg.auto_trade
     market_prefix = "HK" if mode == "HK" else "US"
 
     loop.config = replace(base_cfg, symbols_list=symbols, auto_trade=auto_trade)
     loop.symbols = symbols
-    loop.futu_connector.set_market_prefix(market_prefix)
+    if hasattr(loop.futu_connector, "set_market_prefix"):
+        loop.futu_connector.set_market_prefix(market_prefix)
     
     # New: Ensure we are subscribed to the current symbol list for real-time quotes
     sub_targets = symbols if mode != "IDLE" else IDLE_COLLECTION_SYMBOLS
-    loop.futu_connector.subscribe_symbols(sub_targets)
+    if hasattr(loop.futu_connector, "subscribe_symbols"):
+        loop.futu_connector.subscribe_symbols(sub_targets)
 
     for symbol in symbols:
         _ensure_symbol_state(loop, symbol)
 
     if prev_mode != mode:
-        _load_market_model(loop, mode)
+        _load_market_model(loop, mode, config_path)
 
     if prev_mode is None:
         loop.logger.info("[MARKET_INIT:%s] symbols=%s auto_trade=%s", mode, symbols, auto_trade)
@@ -475,7 +520,7 @@ async def _run_market_aware(
         base_cfg = _base_live_config(config_path)
         if disable_trade:
             base_cfg = replace(base_cfg, auto_trade=False)
-        await _apply_market_mode(loop, base_cfg, mode, prev_mode)
+        await _apply_market_mode(loop, base_cfg, mode, prev_mode, config_path)
 
         if loop.symbols:
             if prev_mode != mode:
@@ -541,12 +586,12 @@ def run_kiro_v35(*, dry_run: bool = False, once: bool = False, config_path: str 
 
     now = datetime.now(HK_TZ)
     initial_mode = resolve_market_mode(now)
-    _load_market_model(loop, initial_mode)
+    _load_market_model(loop, initial_mode, config_path)
 
     if dry_run:
         _enable_dry_run_log_prefix()
 
-    loop.futu_connector.connect(symbols=loop.config.symbols_list)
+    _safe_connector_connect(loop.futu_connector, loop.config.symbols_list)
     _reset_crash_count()  # Reset crash counter on clean startup
     
     # 2026-04-24 Fix: Graceful crash recovery with cooldown
@@ -580,7 +625,7 @@ def run_kiro_v35(*, dry_run: bool = False, once: bool = False, config_path: str 
                 import time as _time
                 loop.futu_connector.close()
                 _time.sleep(cooldown_seconds)
-                loop.futu_connector.connect(symbols=loop.config.symbols_list)
+                _safe_connector_connect(loop.futu_connector, loop.config.symbols_list)
                 loop.logger.info("Reconnected after cooldown, resuming...")
             except Exception as reconnect_err:
                 loop.logger.error("Reconnection failed: %s — aborting", reconnect_err)

--- a/v3_pipeline/models/manager.py
+++ b/v3_pipeline/models/manager.py
@@ -24,6 +24,7 @@ except ImportError:
 from v3_pipeline.data.downloader import HistoricalDataDownloader
 from v3_pipeline.features.indicators import TechnicalIndicatorGenerator
 from v3_pipeline.models.brain import KiroLSTM
+from v3_pipeline.models.registry import ModelRegistry
 
 PATTERN_LABELS = [
     "Unknown",
@@ -372,6 +373,7 @@ class ModelManager:
         data_preparer: DataPreparer,
         device: Optional[str] = None,
         model_dir: str = "v3_pipeline/models/trained_models",
+        registry: Optional[ModelRegistry] = None,
     ) -> None:
         self.logger = _build_stderr_logger(self.__class__.__name__)
         self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
@@ -379,6 +381,7 @@ class ModelManager:
         self.data_preparer = data_preparer
         self.model_dir = Path(model_dir)
         self.model_dir.mkdir(parents=True, exist_ok=True)
+        self.registry = registry or ModelRegistry.from_file(self.model_dir)
 
     @classmethod
     def build_global_pretraining_manager(cls, sample_frame: pd.DataFrame, config: Optional[GlobalPretrainConfig] = None) -> "ModelManager":
@@ -645,10 +648,105 @@ class ModelManager:
         self.logger.info("Saved model checkpoint to %s", target)
         return target
 
+    def _infer_lstm_dims(self, state_dict: dict) -> tuple[int, int, int]:
+        """Read ``input_dim``, ``hidden_dim``, ``num_layers`` from an LSTM state_dict."""
+        # nn.LSTM stores weight_ih_l{i} with shape [4*hidden_dim, input_dim].
+        weight_ih = state_dict.get("lstm.weight_ih_l0")
+        if weight_ih is None:
+            raise ValueError("Checkpoint missing 'lstm.weight_ih_l0' — incompatible with KiroLSTM/AttentiveKiroLSTM.")
+        four_h, input_dim = int(weight_ih.shape[0]), int(weight_ih.shape[1])
+        hidden_dim = four_h // 4
+        num_layers = sum(1 for k in state_dict if k.startswith("lstm.weight_ih_l"))
+        return input_dim, hidden_dim, max(1, num_layers)
+
+    def _load_state_dict_compat(self, state_dict: dict) -> None:
+        """Load a state_dict, rebuilding the model if architecture differs.
+
+        Handles two real cases:
+          1. Saved as AttentiveKiroLSTM (has ``attn.*``/``norm.*`` keys), current
+             model is plain KiroLSTM — rebuild as AttentiveKiroLSTM.
+          2. Input dim mismatch — rebuild with the saved input dim.
+        """
+        try:
+            input_dim, hidden_dim, num_layers = self._infer_lstm_dims(state_dict)
+        except ValueError:
+            # Unknown layout — best effort, non-strict.
+            self.model.load_state_dict(state_dict, strict=False)
+            return
+
+        has_attn = any(k.startswith("attn.") for k in state_dict)
+        has_norm = any(k.startswith("norm.") for k in state_dict)
+
+        # Probe current fc to keep output_dim consistent.
+        fc = getattr(self.model, "fc", None)
+        output_dim = int(fc.out_features) if fc is not None else 1
+        # Read dropout off current model if present.
+        existing_dropout = getattr(self.model, "dropout", None)
+        dropout_p = float(existing_dropout.p) if existing_dropout is not None else 0.2
+
+        needs_rebuild = (
+            (has_attn or has_norm) and not isinstance(self.model, AttentiveKiroLSTM)
+        ) or (
+            getattr(self.model, "lstm", None) is not None
+            and int(self.model.lstm.input_size) != input_dim
+        )
+
+        if needs_rebuild:
+            if has_attn or has_norm:
+                # Infer attention head count from in_proj_weight shape if available.
+                attn_heads = 4
+                self.logger.info(
+                    "Rebuilding model as AttentiveKiroLSTM(input=%d, hidden=%d, layers=%d, heads=%d)",
+                    input_dim, hidden_dim, num_layers, attn_heads,
+                )
+                self.model = AttentiveKiroLSTM(
+                    input_dim=input_dim,
+                    hidden_dim=hidden_dim,
+                    num_layers=num_layers,
+                    dropout=dropout_p,
+                    output_dim=output_dim,
+                    attention_heads=attn_heads,
+                ).to(self.device)
+            else:
+                self.logger.info(
+                    "Rebuilding model as KiroLSTM(input=%d, hidden=%d, layers=%d)",
+                    input_dim, hidden_dim, num_layers,
+                )
+                self.model = KiroLSTM(
+                    input_dim=input_dim,
+                    hidden_dim=hidden_dim,
+                    num_layers=num_layers,
+                    dropout=dropout_p,
+                    output_dim=output_dim,
+                ).to(self.device)
+
+        missing, unexpected = self.model.load_state_dict(state_dict, strict=False)
+        if missing or unexpected:
+            self.logger.warning(
+                "load_state_dict non-strict: missing=%d unexpected=%d",
+                len(missing), len(unexpected),
+            )
+
     def load(self, model_name: str) -> None:
-        source = self.model_dir / f"{model_name}.pth"
+        source = self.registry.resolve(model_name) if self.registry else None
+        if source is None:
+            tried = [str(p) for p in (self.registry.candidates(model_name) if self.registry else [self.model_dir / f"{model_name}.pth"])]
+            raise FileNotFoundError(
+                f"No checkpoint found for '{model_name}'. Tried: {tried}. "
+                f"Edit v3_pipeline/models/models_registry.json to add an alias."
+            )
+
+        if source.stem != model_name:
+            self.logger.info("Resolved model '%s' -> %s", model_name, source.name)
+
         payload = torch.load(source, map_location=self.device)
-        self.model.load_state_dict(payload["model_state_dict"])
+        # Tolerate both wrapped checkpoints and raw state_dicts.
+        if isinstance(payload, dict) and "model_state_dict" in payload:
+            state_dict = payload["model_state_dict"]
+        else:
+            state_dict = payload
+            payload = {}
+        self._load_state_dict_compat(state_dict)
 
         self.data_preparer.lookback = int(payload.get("lookback", self.data_preparer.lookback))
         self.data_preparer.target_col = str(payload.get("target_col", self.data_preparer.target_col))

--- a/v3_pipeline/models/models_registry.json
+++ b/v3_pipeline/models/models_registry.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Logical-name -> checkpoint-stem mapping. Edit aliases to swap models without code changes. 'default' is used when neither an alias nor a direct file matches.",
+  "default": "global_state_v4_1_best",
+  "aliases": {
+    "v3_us_stocks": "global_state_v4_1_best",
+    "v3_hk_stocks": "global_state_v4_1_best"
+  }
+}

--- a/v3_pipeline/models/registry.py
+++ b/v3_pipeline/models/registry.py
@@ -1,0 +1,89 @@
+"""Model registry for resolving logical model names to checkpoint files.
+
+Lets the rest of the system refer to logical names like ``v3_us_stocks`` or
+``v3_hk_stocks`` and have them resolve to whatever checkpoint is currently
+deployed. Switching models is then a one-line edit in
+``models_registry.json`` instead of a code change.
+
+Resolution order (first hit wins):
+    1. Alias defined in ``aliases`` map (logical -> stem)
+    2. Direct file ``<model_dir>/<name>.pth``
+    3. ``default`` stem from registry, if set
+
+The registry is a small JSON file so ops can edit it without touching code.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+DEFAULT_REGISTRY_PATH = Path("v3_pipeline/models/models_registry.json")
+
+
+class ModelRegistry:
+    def __init__(
+        self,
+        model_dir: Path,
+        aliases: Optional[Dict[str, str]] = None,
+        default: Optional[str] = None,
+        registry_path: Optional[Path] = None,
+    ) -> None:
+        self.model_dir = Path(model_dir)
+        self.aliases: Dict[str, str] = dict(aliases or {})
+        self.default: Optional[str] = default
+        self.registry_path = registry_path
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    @classmethod
+    def from_file(
+        cls,
+        model_dir: Path,
+        registry_path: Path = DEFAULT_REGISTRY_PATH,
+    ) -> "ModelRegistry":
+        if not registry_path.exists():
+            return cls(model_dir=model_dir, registry_path=registry_path)
+        try:
+            data = json.loads(registry_path.read_text(encoding="utf-8"))
+        except Exception:
+            return cls(model_dir=model_dir, registry_path=registry_path)
+        return cls(
+            model_dir=model_dir,
+            aliases=dict(data.get("aliases") or {}),
+            default=data.get("default"),
+            registry_path=registry_path,
+        )
+
+    def resolve(self, name: str) -> Optional[Path]:
+        """Return checkpoint path for ``name`` or ``None`` if unresolved."""
+        seen: set[str] = set()
+        current = name
+        # Follow alias chain (alias -> alias -> stem); guard against cycles.
+        while current in self.aliases and current not in seen:
+            seen.add(current)
+            current = self.aliases[current]
+
+        candidate = self.model_dir / f"{current}.pth"
+        if candidate.exists():
+            return candidate
+
+        if self.default and self.default != current:
+            fallback = self.model_dir / f"{self.default}.pth"
+            if fallback.exists():
+                return fallback
+        return None
+
+    def candidates(self, name: str) -> List[Path]:
+        """All paths that would be tried for ``name``, in order."""
+        out: List[Path] = []
+        seen: set[str] = set()
+        current = name
+        while current in self.aliases and current not in seen:
+            seen.add(current)
+            current = self.aliases[current]
+        out.append(self.model_dir / f"{current}.pth")
+        if self.default and self.default != current:
+            out.append(self.model_dir / f"{self.default}.pth")
+        return out


### PR DESCRIPTION
## Problem
- v3_launcher tries to load v3_us_stocks.pth and v3_hk_stocks.pth which do not exist
- global_state_v4_1_best.pth uses AttentiveKiroLSTM architecture, but launcher creates KiroLSTM
- Strict state_dict load fails due to unexpected keys (attn, norm layers)

## Solution
### 1. Model Registry (v3_pipeline/models/registry.py)
- Maps logical names (e.g., v3_us_stocks) to checkpoint stems via alias chain
- Falls back to a default model if direct file not found
- Ops can edit models_registry.json to swap models without code changes

### 2. Smart Architecture Rebuild (ModelManager._load_state_dict_compat())
- Detects saved model architecture by inspecting state_dict keys
- Automatically rebuilds model if AttentiveKiroLSTM detected
- Infers input_dim/hidden_dim/num_layers from LSTM weight shapes
- Gracefully handles non-strict loads for compatibility

### 3. Config-Driven Model Selection (config.json -> model.markets)
- Per-market model assignment (HK, US, IDLE) via configuration
- Easy to change models without touching code
- Reads from config.json model.markets[mode]

### 4. Fallback Chain (_load_market_model())
- Tries primary market's model first
- Falls back to sibling market (HK → US, US → HK) if primary fails
- Logs all attempts and errors for debugging

## Benefits
✅ Resolves FileNotFoundError: v3_us_stocks.pth and v3_hk_stocks.pth now work via aliases
✅ Handles architecture mismatch automatically (no more state_dict key errors)
✅ Model switching is configuration-only (edit config.json or models_registry.json)
✅ Graceful degradation with fallback chain

## Files Changed
- v3_pipeline/models/registry.py (new) - ModelRegistry class
- v3_pipeline/models/models_registry.json (new) - Alias mapping
- v3_pipeline/models/manager.py - Added compat loader, registry support
- v3_launcher.py - Config-driven model selection, fallback chain
- config.json - Added model.markets block for per-market assignment
