### PR TITLE
fix: circuit breaker 零 equity 誤觸發 + Futu SDK 連線超時防護

### DIFF
--- a/tests/test_circuit_breaker_zero_equity.py
+++ b/tests/test_circuit_breaker_zero_equity.py
@@ -1,0 +1,245 @@
+"""Tests for circuit breaker false-trigger guard when broker returns zero equity.
+
+Scenario: In SIMULATE/paper mode the Futu broker sometimes returns total_assets=0
+(unfunded SIM account or transient connectivity issue).  Before the fix this caused
+account_value to be set to 0, producing a 100% drawdown vs the initial 100 000
+equity_peak and firing the circuit breaker on every _execute() call.
+
+Fix in _sync_broker_state(): only update account_value when broker returns a
+positive value; otherwise preserve the last known value and emit a structured log.
+"""
+import json
+import sys
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+
+# ── stubs required before importing main_loop ───────────────────────────────
+@dataclass
+class _StubPreparer:
+    lookback: int = 2
+    target_col: str = "Close"
+    is_fitted: bool = True
+    feature_columns: list = None
+
+    def fit_transform(self, frame):
+        self.is_fitted = True
+        self.feature_columns = [c for c in frame.columns if c != "Date"]
+        return frame
+
+
+sys.modules.setdefault("requests", SimpleNamespace(post=lambda *a, **k: None))
+sys.modules.setdefault(
+    "v3_pipeline.models.manager",
+    SimpleNamespace(
+        DataPreparer=lambda **kwargs: _StubPreparer(**kwargs),
+        ModelManager=object,
+    ),
+)
+
+from v3_pipeline.core.main_loop import LiveConfig, LiveTradingLoop  # noqa: E402
+from v3_pipeline.risk.manager import RiskConfig, RiskController  # noqa: E402
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+class _ZeroAssetConnector:
+    """Broker that always returns total_assets=0 (SIM account unfunded)."""
+
+    class config:
+        market_prefix = "US"
+
+    def connect(self):
+        return None
+
+    def close(self):
+        return None
+
+    def heartbeat(self):
+        return True
+
+    def get_sync_assets(self):
+        return {"total_assets": 0.0}
+
+    def get_sync_positions(self):
+        return pd.DataFrame(columns=["code", "qty", "can_sell_qty"])
+
+    def get_latest_quote(self, symbol):
+        return {
+            "Date": pd.Timestamp("2026-05-08T10:00:00Z"),
+            "Open": 100.0,
+            "High": 101.0,
+            "Low": 99.0,
+            "Close": 100.0,
+            "Volume": 10_000,
+            "data_source": "test",
+            "symbol": symbol,
+        }
+
+    def get_order_reference_price(self, _symbol, _side, fallback_price):
+        return fallback_price
+
+    def get_open_orders(self):
+        return pd.DataFrame([])
+
+
+class _PositiveAssetConnector(_ZeroAssetConnector):
+    """Broker that returns a meaningful total_assets value."""
+
+    def get_sync_assets(self):
+        return {"total_assets": 200_000.0}
+
+
+def _make_loop(connector=None, symbols=None):
+    symbols = symbols or ["AAPL"]
+    cfg = LiveConfig(
+        symbol=symbols[0],
+        symbols_list=symbols,
+        prediction_threshold=0.01,
+        prediction_thresholds={s: 0.01 for s in symbols},
+        auto_trade=True,
+        paper_trading=False,
+        log_trade_decisions=False,
+        polling_seconds=1,
+    )
+    loop = LiveTradingLoop(
+        model_manager=SimpleNamespace(
+            data_preparer=_StubPreparer(),
+            predict=lambda *a, **k: 100.0,
+        ),
+        risk_controller=RiskController(config=RiskConfig(max_drawdown=0.20)),
+        futu_connector=connector or _ZeroAssetConnector(),
+        data_manager=None,
+        feature_generator=SimpleNamespace(generate=lambda f: f),
+        config=cfg,
+    )
+    return loop
+
+
+# ── tests ────────────────────────────────────────────────────────────────────
+
+class TestBrokerSyncZeroEquityGuard:
+    def test_account_value_not_zeroed_when_broker_returns_zero(self):
+        """account_value must stay at its last known value when broker returns 0."""
+        loop = _make_loop(connector=_ZeroAssetConnector())
+        loop.account_value = 100_000.0
+
+        loop._sync_broker_state()
+
+        assert loop.account_value == 100_000.0, (
+            "account_value was overwritten to 0; circuit breaker would fire on every trade"
+        )
+
+    def test_account_value_updated_when_broker_returns_positive(self):
+        """account_value must be updated when broker returns a positive value."""
+        loop = _make_loop(connector=_PositiveAssetConnector())
+        loop.account_value = 100_000.0
+
+        loop._sync_broker_state()
+
+        assert loop.account_value == 200_000.0
+
+    def test_circuit_breaker_does_not_fire_after_zero_equity_sync(self):
+        """With the fix, a zero-equity broker response must NOT trigger circuit breaker."""
+        loop = _make_loop(connector=_ZeroAssetConnector())
+        loop.account_value = 100_000.0
+        loop.equity_peak = 100_000.0
+
+        loop._sync_broker_state()
+
+        fired = loop.risk_controller.circuit_breaker_triggered(
+            loop.equity_peak, loop.account_value
+        )
+        assert not fired, (
+            "Circuit breaker fired after zero-equity broker sync; "
+            "account_value should have been preserved"
+        )
+
+    def test_zero_equity_emits_structured_log_event(self, capsys):
+        """broker_sync_zero_equity structured event must be emitted when broker returns 0."""
+        loop = _make_loop(connector=_ZeroAssetConnector())
+        loop.account_value = 50_000.0
+
+        events = []
+        original_emit = loop._emit_structured
+
+        def _capture_emit(event_type, **fields):
+            events.append({"event": event_type, **fields})
+            original_emit(event_type, **fields)
+
+        loop._emit_structured = _capture_emit
+        loop._sync_broker_state()
+
+        assert any(e["event"] == "broker_sync_zero_equity" for e in events), (
+            "Expected broker_sync_zero_equity structured event not emitted"
+        )
+        evt = next(e for e in events if e["event"] == "broker_sync_zero_equity")
+        assert evt["kept_value"] == 50_000.0
+
+    def test_account_value_preserved_across_multiple_zero_syncs(self):
+        """Multiple consecutive zero-equity syncs must not drift account_value."""
+        loop = _make_loop(connector=_ZeroAssetConnector())
+        loop.account_value = 75_000.0
+
+        for _ in range(5):
+            loop._sync_broker_state()
+
+        assert loop.account_value == 75_000.0
+
+    def test_positive_equity_after_zero_resets_correctly(self):
+        """After zero-equity phase, a positive broker response must update account_value."""
+        class _FlippingConnector(_ZeroAssetConnector):
+            def __init__(self):
+                self._call = 0
+
+            def get_sync_assets(self):
+                self._call += 1
+                return {"total_assets": 0.0 if self._call <= 2 else 120_000.0}
+
+        loop = _make_loop(connector=_FlippingConnector())
+        loop.account_value = 100_000.0
+
+        loop._sync_broker_state()  # call 1 — zero, preserve 100k
+        assert loop.account_value == 100_000.0
+
+        loop._sync_broker_state()  # call 2 — zero, preserve 100k
+        assert loop.account_value == 100_000.0
+
+        loop._sync_broker_state()  # call 3 — positive 120k, update
+        assert loop.account_value == 120_000.0
+
+
+class TestCircuitBreakerStandaloneLogic:
+    """Unit tests for RiskController.circuit_breaker_triggered."""
+
+    def test_no_trigger_when_equity_peak_zero(self):
+        ctrl = RiskController(config=RiskConfig(max_drawdown=0.20))
+        assert not ctrl.circuit_breaker_triggered(0.0, 0.0)
+
+    def test_trigger_on_large_drawdown(self):
+        ctrl = RiskController(config=RiskConfig(max_drawdown=0.20))
+        # 100k peak, 70k current = 30% drawdown > 20% limit
+        assert ctrl.circuit_breaker_triggered(100_000.0, 70_000.0)
+
+    def test_no_trigger_within_limit(self):
+        ctrl = RiskController(config=RiskConfig(max_drawdown=0.20))
+        # 100k peak, 85k current = 15% drawdown < 20% limit
+        assert not ctrl.circuit_breaker_triggered(100_000.0, 85_000.0)
+
+    def test_no_trigger_at_exact_limit(self):
+        ctrl = RiskController(config=RiskConfig(max_drawdown=0.20))
+        # 100k peak, 80k current = exactly 20% — boundary: triggered only when >=
+        assert ctrl.circuit_breaker_triggered(100_000.0, 80_000.0)
+
+    def test_simulate_zero_equity_false_positive_scenario(self):
+        """Before fix: zero broker equity with 100k peak would trigger circuit breaker."""
+        ctrl = RiskController(config=RiskConfig(max_drawdown=0.20))
+        # This is the scenario that happens WITHOUT the fix
+        equity_peak = 100_000.0  # set from initial account_value
+        current_equity = 0.0     # broker returned 0
+        # Without the fix, this fires — drawdown = 100%
+        assert ctrl.circuit_breaker_triggered(equity_peak, current_equity)
+        # The fix prevents current_equity from being 0 in the first place

--- a/tests/test_idle_collect.py
+++ b/tests/test_idle_collect.py
@@ -1,0 +1,385 @@
+"""Tests for _collect_only_cycle per-symbol timeout handling.
+
+Bug fixed: asyncio.TimeoutError was caught at the batch level, so one slow
+symbol would cause the remaining symbols in that batch to be silently skipped.
+
+Fix: timeout is now caught per-symbol so each symbol is independently
+skipped on timeout, and the rest of the batch continues.
+"""
+import asyncio
+import logging
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pandas as pd
+import pytest
+
+
+# ── module-level stubs so v3_launcher can be imported in a test environment ──
+
+def _make_stub_preparer(**kwargs):
+    p = MagicMock()
+    p.lookback = kwargs.get("lookback", 2)
+    p.is_fitted = True
+    p.feature_columns = []
+    p.fit_transform = lambda f: f
+    return p
+
+
+sys.modules.setdefault("requests", SimpleNamespace(post=lambda *a, **k: None))
+sys.modules.setdefault(
+    "v3_pipeline.models.manager",
+    SimpleNamespace(
+        DataPreparer=_make_stub_preparer,
+        ModelManager=object,
+    ),
+)
+sys.modules.setdefault(
+    "v3_pipeline.models.brain",
+    SimpleNamespace(KiroLSTM=object),
+)
+sys.modules.setdefault(
+    "v3_pipeline.risk.manager",
+    SimpleNamespace(RiskConfig=object, RiskController=object),
+)
+sys.modules.setdefault(
+    "v3_pipeline.features.screener",
+    SimpleNamespace(V3FunnelScreener=object),
+)
+sys.modules.setdefault(
+    "v3_pipeline.core.market_analyzer",
+    SimpleNamespace(MarketAnalyzer=object),
+)
+
+from v3_launcher import _collect_only_cycle  # noqa: E402
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+_COLS = ["Date", "Open", "High", "Low", "Close", "Volume", "data_source"]
+
+
+def _quote(symbol: str = "SYM", price: float = 100.0) -> dict:
+    return {
+        "Date": pd.Timestamp("2026-05-08T10:00:00Z"),
+        "Open": price,
+        "High": price + 1,
+        "Low": price - 1,
+        "Close": price,
+        "Volume": 10_000,
+        "data_source": "test",
+        "symbol": symbol,
+    }
+
+
+def _make_loop(symbols: list[str], logger=None):
+    """Build a minimal loop-like namespace for _collect_only_cycle."""
+    buffers = {s: pd.DataFrame(columns=_COLS) for s in symbols}
+    connector = MagicMock()
+    log = logger or logging.getLogger("test_idle_collect")
+
+    def _normalize(df):
+        return df.reset_index(drop=True)
+
+    return SimpleNamespace(
+        market_buffers=buffers,
+        futu_connector=connector,
+        logger=log,
+        _normalize_market_buffer=_normalize,
+    )
+
+
+def _make_wait_for(symbol_results: dict):
+    """
+    Return a patched asyncio.wait_for that delivers results per-symbol.
+
+    symbol_results: maps symbol name → return value or exception instance.
+    The call order tracks how many times wait_for was called to figure out
+    which symbol is being fetched.
+    """
+    counter = {"n": 0}
+    symbols_in_order = list(symbol_results.keys())
+
+    async def _patched(coro, timeout):
+        coro.close()
+        sym = symbols_in_order[counter["n"]]
+        counter["n"] += 1
+        result = symbol_results[sym]
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    return _patched
+
+
+# ── per-symbol timeout isolation ─────────────────────────────────────────────
+
+
+class TestPerSymbolTimeoutIsolation:
+    """A timeout on one symbol must not skip remaining symbols in the batch."""
+
+    def test_timeout_on_first_symbol_does_not_skip_rest(self):
+        """When sym0 times out, sym1..sym4 must still be fetched."""
+        symbols = [f"SYM{i}" for i in range(5)]
+        results = {
+            "SYM0": asyncio.TimeoutError(),
+            "SYM1": _quote("SYM1"),
+            "SYM2": _quote("SYM2"),
+            "SYM3": _quote("SYM3"),
+            "SYM4": _quote("SYM4"),
+        }
+
+        async def _run():
+            loop = _make_loop(symbols)
+            with patch("v3_launcher.asyncio.wait_for", side_effect=_make_wait_for(results)):
+                with patch("v3_launcher.asyncio.sleep", new_callable=AsyncMock):
+                    await _collect_only_cycle(loop, symbols)
+            return loop
+
+        loop = asyncio.run(_run())
+
+        assert loop.market_buffers["SYM0"].empty, "SYM0 timed out, should be empty"
+        for sym in symbols[1:]:
+            assert not loop.market_buffers[sym].empty, f"{sym} should be populated"
+
+    def test_all_symbols_fetched_when_middle_times_out(self):
+        """Timeout on a middle symbol skips only that symbol."""
+        symbols = ["AAA", "BBB", "CCC"]
+        results = {
+            "AAA": _quote("AAA"),
+            "BBB": asyncio.TimeoutError(),
+            "CCC": _quote("CCC"),
+        }
+
+        async def _run():
+            loop = _make_loop(symbols)
+            with patch("v3_launcher.asyncio.wait_for", side_effect=_make_wait_for(results)):
+                with patch("v3_launcher.asyncio.sleep", new_callable=AsyncMock):
+                    await _collect_only_cycle(loop, symbols)
+            return loop
+
+        loop = asyncio.run(_run())
+
+        assert not loop.market_buffers["AAA"].empty
+        assert loop.market_buffers["BBB"].empty
+        assert not loop.market_buffers["CCC"].empty
+
+    def test_error_on_one_symbol_does_not_skip_rest(self):
+        """RuntimeError on one symbol must not skip remaining symbols."""
+        symbols = ["X1", "X2", "X3"]
+        results = {
+            "X1": RuntimeError("provider unavailable"),
+            "X2": _quote("X2"),
+            "X3": _quote("X3"),
+        }
+
+        async def _run():
+            loop = _make_loop(symbols)
+            with patch("v3_launcher.asyncio.wait_for", side_effect=_make_wait_for(results)):
+                with patch("v3_launcher.asyncio.sleep", new_callable=AsyncMock):
+                    await _collect_only_cycle(loop, symbols)
+            return loop
+
+        loop = asyncio.run(_run())
+
+        assert loop.market_buffers["X1"].empty
+        assert not loop.market_buffers["X2"].empty
+        assert not loop.market_buffers["X3"].empty
+
+    def test_timeout_count_logged_in_warning(self):
+        """Warning with timed_out count is emitted when at least one symbol times out."""
+        symbols = ["T1", "T2"]
+        results = {
+            "T1": asyncio.TimeoutError(),
+            "T2": _quote("T2"),
+        }
+
+        log = logging.getLogger("test.timeout_log")
+        warn_msgs = []
+        original_warning = log.warning
+        log.warning = lambda msg, *a, **k: warn_msgs.append(msg % a if a else msg)
+
+        async def _run():
+            loop = _make_loop(symbols, logger=log)
+            with patch("v3_launcher.asyncio.wait_for", side_effect=_make_wait_for(results)):
+                with patch("v3_launcher.asyncio.sleep", new_callable=AsyncMock):
+                    await _collect_only_cycle(loop, symbols)
+
+        asyncio.run(_run())
+        log.warning = original_warning
+
+        assert any("timed_out=1" in m for m in warn_msgs), \
+            f"Expected timed_out=1 in warning, got: {warn_msgs}"
+
+    def test_no_warning_when_all_succeed(self):
+        """No WARNING is emitted when every symbol returns a valid quote."""
+        symbols = ["OK1", "OK2", "OK3"]
+        results = {s: _quote(s) for s in symbols}
+
+        log = logging.getLogger("test.no_warn")
+        warn_msgs = []
+        original_warning = log.warning
+        log.warning = lambda msg, *a, **k: warn_msgs.append(msg % a if a else msg)
+
+        async def _run():
+            loop = _make_loop(symbols, logger=log)
+            with patch("v3_launcher.asyncio.wait_for", side_effect=_make_wait_for(results)):
+                with patch("v3_launcher.asyncio.sleep", new_callable=AsyncMock):
+                    await _collect_only_cycle(loop, symbols)
+
+        asyncio.run(_run())
+        log.warning = original_warning
+
+        assert not warn_msgs, f"Unexpected warnings: {warn_msgs}"
+
+
+# ── buffer update logic ───────────────────────────────────────────────────────
+
+
+class TestBufferUpdate:
+    """Buffer update logic: valid quotes are stored, None/empty quotes are ignored."""
+
+    def test_valid_quote_populates_buffer(self):
+        """A valid quote dict updates market_buffers for that symbol."""
+        symbols = ["VALID"]
+        results = {"VALID": _quote("VALID", price=55.0)}
+
+        async def _run():
+            loop = _make_loop(symbols)
+            with patch("v3_launcher.asyncio.wait_for", side_effect=_make_wait_for(results)):
+                with patch("v3_launcher.asyncio.sleep", new_callable=AsyncMock):
+                    await _collect_only_cycle(loop, symbols)
+            return loop
+
+        loop = asyncio.run(_run())
+        buf = loop.market_buffers["VALID"]
+        assert not buf.empty
+        assert buf.iloc[-1]["Close"] == 55.0
+
+    def test_none_quote_does_not_crash(self):
+        """A None return from get_latest_quote is silently ignored."""
+        symbols = ["NONE"]
+        results = {"NONE": None}
+
+        async def _run():
+            loop = _make_loop(symbols)
+            with patch("v3_launcher.asyncio.wait_for", side_effect=_make_wait_for(results)):
+                with patch("v3_launcher.asyncio.sleep", new_callable=AsyncMock):
+                    await _collect_only_cycle(loop, symbols)
+            return loop
+
+        loop = asyncio.run(_run())
+        assert loop.market_buffers["NONE"].empty
+
+    def test_all_nan_quote_does_not_populate_buffer(self):
+        """A quote that becomes all-NaN after DataFrame creation is dropped."""
+        symbols = ["NAN"]
+        results = {
+            "NAN": {"Date": None, "Open": None, "High": None, "Low": None,
+                    "Close": None, "Volume": None, "data_source": None},
+        }
+
+        async def _run():
+            loop = _make_loop(symbols)
+            with patch("v3_launcher.asyncio.wait_for", side_effect=_make_wait_for(results)):
+                with patch("v3_launcher.asyncio.sleep", new_callable=AsyncMock):
+                    await _collect_only_cycle(loop, symbols)
+            return loop
+
+        loop = asyncio.run(_run())
+        assert loop.market_buffers["NAN"].empty
+
+    def test_consecutive_quotes_appended_to_existing_buffer(self):
+        """A second call appends a new row to an already-populated buffer."""
+        symbols = ["SERIES"]
+        prices = [101.0, 102.0]
+
+        async def _run(price):
+            results = {"SERIES": _quote("SERIES", price=price)}
+            loop = _make_loop(symbols)
+            with patch("v3_launcher.asyncio.wait_for", side_effect=_make_wait_for(results)):
+                with patch("v3_launcher.asyncio.sleep", new_callable=AsyncMock):
+                    await _collect_only_cycle(loop, symbols)
+            return loop
+
+        loop1 = asyncio.run(_run(prices[0]))
+        # Second call uses the populated buffers from first
+        loop2 = SimpleNamespace(
+            market_buffers=loop1.market_buffers,
+            futu_connector=loop1.futu_connector,
+            logger=loop1.logger,
+            _normalize_market_buffer=loop1._normalize_market_buffer,
+        )
+
+        results2 = {"SERIES": _quote("SERIES", price=prices[1])}
+
+        async def _run2():
+            with patch("v3_launcher.asyncio.wait_for", side_effect=_make_wait_for(results2)):
+                with patch("v3_launcher.asyncio.sleep", new_callable=AsyncMock):
+                    await _collect_only_cycle(loop2, symbols)
+
+        asyncio.run(_run2())
+        assert len(loop2.market_buffers["SERIES"]) == 2
+
+
+# ── batch sleep behavior ──────────────────────────────────────────────────────
+
+
+class TestBatchSleepBehavior:
+    """Inter-batch sleep is called after each batch regardless of symbol outcome."""
+
+    def test_sleep_called_once_per_batch(self):
+        """asyncio.sleep(2.0) is invoked exactly once for a single batch of 3 symbols."""
+        symbols = ["A", "B", "C"]
+        results = {s: _quote(s) for s in symbols}
+        sleep_calls = []
+
+        async def _patched_sleep(t):
+            sleep_calls.append(t)
+
+        async def _run():
+            loop = _make_loop(symbols)
+            with patch("v3_launcher.asyncio.wait_for", side_effect=_make_wait_for(results)):
+                with patch("v3_launcher.asyncio.sleep", side_effect=_patched_sleep):
+                    await _collect_only_cycle(loop, symbols)
+
+        asyncio.run(_run())
+        assert sleep_calls == [2.0], f"Expected one 2.0-second sleep, got: {sleep_calls}"
+
+    def test_sleep_called_per_batch_across_multiple_batches(self):
+        """With 10 symbols (batch_size=5), sleep is called twice."""
+        symbols = [f"SYM{i}" for i in range(10)]
+        results = {s: _quote(s) for s in symbols}
+        sleep_calls = []
+
+        async def _patched_sleep(t):
+            sleep_calls.append(t)
+
+        async def _run():
+            loop = _make_loop(symbols)
+            with patch("v3_launcher.asyncio.wait_for", side_effect=_make_wait_for(results)):
+                with patch("v3_launcher.asyncio.sleep", side_effect=_patched_sleep):
+                    await _collect_only_cycle(loop, symbols)
+
+        asyncio.run(_run())
+        assert len(sleep_calls) == 2
+        assert all(t == 2.0 for t in sleep_calls)
+
+    def test_sleep_still_called_when_all_symbols_timeout(self):
+        """Even when all symbols time out, sleep is still called between batches."""
+        symbols = ["T1", "T2", "T3"]
+        results = {s: asyncio.TimeoutError() for s in symbols}
+        sleep_calls = []
+
+        async def _patched_sleep(t):
+            sleep_calls.append(t)
+
+        async def _run():
+            loop = _make_loop(symbols)
+            with patch("v3_launcher.asyncio.wait_for", side_effect=_make_wait_for(results)):
+                with patch("v3_launcher.asyncio.sleep", side_effect=_patched_sleep):
+                    await _collect_only_cycle(loop, symbols)
+
+        asyncio.run(_run())
+        assert sleep_calls == [2.0]

--- a/tests/test_opend_stability.py
+++ b/tests/test_opend_stability.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch, call
 import pytest
 
 from v3_pipeline.core.futu_connector import ConnectionState, FutuConfig, FutuConnector
-from v3_launcher import _check_opend_reachable, _wait_for_opend
+from v3_launcher import _check_opend_reachable, _wait_for_opend, _safe_connector_connect
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────
@@ -365,3 +365,102 @@ class TestWaitForOpend:
                     )
         assert result is False
         assert any("timeout" in r.message.lower() for r in caplog.records)
+
+
+# ── _safe_connector_connect timeout guard ──────────────────────────────────────
+
+class TestSafeConnectorConnectTimeout:
+    """Tests for the wall-clock timeout guard in _safe_connector_connect.
+
+    Root cause being guarded: when port 11112 is TCP-reachable but the Futu
+    protocol handshake keeps failing, ``OpenQuoteContext._connect_sync`` retries
+    every 26 s for 21+ minutes, blocking the launcher completely.  The guard
+    runs the SDK connect in a daemon thread and abandons it after
+    ``timeout_seconds``, returning False so the caller proceeds in degraded mode.
+    """
+
+    def test_returns_true_when_connect_succeeds(self):
+        connector = MagicMock()
+        connector.connect = MagicMock()
+        result = _safe_connector_connect(connector, symbols=["AAPL"], timeout_seconds=5.0)
+        assert result is True
+        connector.connect.assert_called_once_with(symbols=["AAPL"])
+
+    def test_returns_true_with_no_symbols(self):
+        connector = MagicMock()
+        connector.connect = MagicMock()
+        result = _safe_connector_connect(connector, symbols=None, timeout_seconds=5.0)
+        assert result is True
+        connector.connect.assert_called_once_with()
+
+    def test_returns_false_when_connect_hangs_past_timeout(self):
+        """Simulates the observed Futu SDK _connect_sync loop that hangs 21 min."""
+        import threading as _threading
+
+        connect_started = _threading.Event()
+
+        def _hanging_connect(**_kwargs):
+            connect_started.set()
+            # Block until the test finishes (simulates unbounded SDK retry)
+            time.sleep(60)
+
+        connector = MagicMock()
+        connector.connect = _hanging_connect
+
+        result = _safe_connector_connect(connector, symbols=["AAPL"], timeout_seconds=0.2)
+        assert result is False
+        # Guard started the thread
+        assert connect_started.is_set()
+
+    def test_emits_structured_log_on_timeout(self, caplog):
+        import logging as _logging
+
+        def _hanging_connect(**_kwargs):
+            time.sleep(60)
+
+        connector = MagicMock()
+        connector.connect = _hanging_connect
+
+        with caplog.at_level(_logging.ERROR, logger="futu_connect_guard"):
+            result = _safe_connector_connect(connector, symbols=["AAPL"], timeout_seconds=0.2)
+
+        assert result is False
+        assert any("futu_connect_timeout" in r.message for r in caplog.records)
+
+    def test_raises_runtime_error_when_connect_raises(self):
+        connector = MagicMock()
+        connector.connect = MagicMock(side_effect=OSError("connection refused"))
+
+        with pytest.raises(RuntimeError, match="Failed to connect"):
+            _safe_connector_connect(connector, symbols=["AAPL"], timeout_seconds=5.0)
+
+    def test_handles_type_error_fallback(self):
+        """Old connector signature raises TypeError on symbols kwarg; shim calls bare connect()."""
+        call_log: list[str] = []
+
+        def _connect_compat(**kwargs):
+            if "symbols" in kwargs:
+                raise TypeError("unexpected keyword argument 'symbols'")
+            call_log.append("bare_connect")
+
+        connector = MagicMock()
+        connector.connect = _connect_compat
+
+        result = _safe_connector_connect(connector, symbols=["AAPL"], timeout_seconds=5.0)
+        assert result is True
+        assert call_log == ["bare_connect"]
+
+    def test_degraded_mode_does_not_block_for_full_sdk_retry_duration(self):
+        """Wall-clock: even if SDK would block for minutes, we return in < 1 s."""
+        def _very_slow_connect(**_kwargs):
+            time.sleep(300)  # 5-minute hang
+
+        connector = MagicMock()
+        connector.connect = _very_slow_connect
+
+        t_start = time.monotonic()
+        result = _safe_connector_connect(connector, symbols=["AAPL"], timeout_seconds=0.3)
+        elapsed = time.monotonic() - t_start
+
+        assert result is False
+        assert elapsed < 1.0, f"Expected < 1 s, got {elapsed:.2f} s"

--- a/v3_launcher.py
+++ b/v3_launcher.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import os
 import socket
+import threading
 import time  # 2026-04-24: for cooldown
 import argparse
 import logging
@@ -424,15 +425,59 @@ def _wait_for_opend(
     return False
 
 
-def _safe_connector_connect(connector, symbols: list[str] | None = None) -> None:
-    """Connector compatibility shim for old/new FutuConnector signatures."""
-    try:
-        if symbols is not None:
-            connector.connect(symbols=symbols)
-        else:
-            connector.connect()
-    except TypeError:
-        connector.connect()
+def _safe_connector_connect(
+    connector,
+    symbols: list[str] | None = None,
+    timeout_seconds: float = 90.0,
+    logger: logging.Logger | None = None,
+) -> bool:
+    """Connect to Futu connector with a wall-clock timeout.
+
+    The Futu SDK's internal ``_connect_sync`` loop can hang for 20+ minutes when
+    port 11112 is TCP-reachable but the protocol handshake keeps timing out.
+    This guard runs the blocking connect in a daemon thread and abandons it after
+    ``timeout_seconds``, letting the caller proceed in degraded (no-Futu) mode.
+
+    Returns True on success, False if the connection timed out.
+    Raises RuntimeError if the connector itself raises an exception before timeout.
+
+    Config key: ``futu_connect_timeout_seconds`` (default 90).
+    """
+    _log = logger or logging.getLogger("futu_connect_guard")
+    error: list[Exception | None] = [None]
+
+    def _do_connect() -> None:
+        try:
+            if symbols is not None:
+                connector.connect(symbols=symbols)
+            else:
+                connector.connect()
+        except TypeError:
+            try:
+                connector.connect()
+            except Exception as exc:
+                error[0] = exc
+        except Exception as exc:
+            error[0] = exc
+
+    t = threading.Thread(target=_do_connect, daemon=True, name="futu_connect")
+    t.start()
+    t.join(timeout=timeout_seconds)
+
+    if t.is_alive():
+        # SDK connect still running — proceed in degraded mode; daemon thread
+        # will be cleaned up on process exit.
+        _log.error(
+            '{"event":"futu_connect_timeout","timeout_s":%.1f,'
+            '"msg":"Futu SDK connect hung; proceeding in degraded mode"}',
+            timeout_seconds,
+        )
+        return False
+
+    if error[0] is not None:
+        raise RuntimeError(f"Failed to connect to Futu OpenD: {error[0]}") from error[0]
+
+    return True
 
 
 async def _apply_market_mode(loop: "LiveTradingLoop", base_cfg: "LiveConfig", mode: str, prev_mode: str | None, config_path: str = "config.json") -> None:
@@ -694,13 +739,18 @@ def run_kiro_v35(*, dry_run: bool = False, once: bool = False, config_path: str 
     _opend_host = cfg.get("futu", cfg.get("futu_api_config", {})).get("host", "127.0.0.1")
     _opend_port = int(cfg.get("futu", cfg.get("futu_api_config", {})).get("port", 11112))
     _opend_max_wait = float(cfg.get("opend_guard_max_wait_seconds", 60.0))
+    _connect_timeout = float(cfg.get("futu_connect_timeout_seconds", 90.0))
     if not _wait_for_opend(host=_opend_host, port=_opend_port, max_wait_seconds=_opend_max_wait, logger=loop.logger):
         loop.logger.error(
             "OpenD not reachable at %s:%d after %.0fs — starting in degraded (collect-only) mode",
             _opend_host, _opend_port, _opend_max_wait,
         )
 
-    _safe_connector_connect(loop.futu_connector, loop.config.symbols_list)
+    if not _safe_connector_connect(loop.futu_connector, loop.config.symbols_list, timeout_seconds=_connect_timeout, logger=loop.logger):
+        loop.logger.warning(
+            "Futu connect timed out (%.0fs) — starting in degraded (collect-only) mode",
+            _connect_timeout,
+        )
     _reset_crash_count()  # Reset crash counter on clean startup
     
     # 2026-04-24 Fix: Graceful crash recovery with cooldown
@@ -734,8 +784,18 @@ def run_kiro_v35(*, dry_run: bool = False, once: bool = False, config_path: str 
                 import time as _time
                 loop.futu_connector.close()
                 _time.sleep(cooldown_seconds)
-                _safe_connector_connect(loop.futu_connector, loop.config.symbols_list)
-                loop.logger.info("Reconnected after cooldown, resuming...")
+                if not _safe_connector_connect(
+                    loop.futu_connector,
+                    loop.config.symbols_list,
+                    timeout_seconds=_connect_timeout,
+                    logger=loop.logger,
+                ):
+                    loop.logger.warning(
+                        "Reconnect timed out (%.0fs) — continuing in degraded mode",
+                        _connect_timeout,
+                    )
+                else:
+                    loop.logger.info("Reconnected after cooldown, resuming...")
             except Exception as reconnect_err:
                 loop.logger.warning(
                     "Reconnection failed: %s — continuing in degraded (collect-only) mode",

--- a/v3_launcher.py
+++ b/v3_launcher.py
@@ -562,13 +562,16 @@ async def _apply_market_mode(loop: "LiveTradingLoop", base_cfg: "LiveConfig", mo
 async def _collect_only_cycle(loop: "LiveTradingLoop", symbols: list[str]) -> None:
     """During IDLE: only fetch latest bars to keep buffers warm, no trades."""
     loop.logger.info("[IDLE_COLLECT] Syncing %d symbols...", len(symbols))
-    for i in range(0, len(symbols), 5):  # Extremely small batch size to avoid rate limits
+    fetched = 0
+    timed_out = 0
+    errors = 0
+    for i in range(0, len(symbols), 5):
         batch = symbols[i : i + 5]
-        try:
-            for sym in batch:
+        for sym in batch:
+            try:
                 quote = await asyncio.wait_for(
                     asyncio.to_thread(loop.futu_connector.get_latest_quote, sym),
-                    timeout=15.0 # Even more generous timeout
+                    timeout=10.0,
                 )
                 if quote:
                     new_row = pd.DataFrame([quote])
@@ -576,19 +579,27 @@ async def _collect_only_cycle(loop: "LiveTradingLoop", symbols: list[str]) -> No
                     # pd.concat when concatenating empty/all-NA frames.
                     new_row = new_row.dropna(how="all")
                     if not new_row.empty:
-                        existing = loop.market_buffers[sym]
+                        existing = loop.market_buffers.get(sym, pd.DataFrame())
                         if existing.empty:
                             loop.market_buffers[sym] = loop._normalize_market_buffer(new_row)
                         else:
                             loop.market_buffers[sym] = loop._normalize_market_buffer(
                                 pd.concat([existing, new_row], ignore_index=True)
                             )
-            # Significant sleep between batches to be very gentle with the API
-            await asyncio.sleep(2.0)
-        except asyncio.TimeoutError:
-            loop.logger.warning("[IDLE_COLLECT] Batch timeout occurred, skipping current batch")
-        except Exception as exc:
-            loop.logger.warning("Idle collect batch failed: %s", exc)
+                        fetched += 1
+            except asyncio.TimeoutError:
+                timed_out += 1
+                loop.logger.debug("[IDLE_COLLECT] %s quote timeout, skipping symbol", sym)
+            except Exception as exc:
+                errors += 1
+                loop.logger.debug("[IDLE_COLLECT] %s quote error: %s", sym, exc)
+        # Sleep between batches to be gentle with the API
+        await asyncio.sleep(2.0)
+    if timed_out or errors:
+        loop.logger.warning(
+            "[IDLE_COLLECT] Completed: fetched=%d timed_out=%d errors=%d / %d symbols",
+            fetched, timed_out, errors, len(symbols),
+        )
 
 
 def _idle_precompute(loop: "LiveTradingLoop", symbols: list[str]) -> None:

--- a/v3_pipeline/core/main_loop.py
+++ b/v3_pipeline/core/main_loop.py
@@ -1747,7 +1747,18 @@ class LiveTradingLoop:
                 assets = self.futu_connector.get_sync_assets_all_markets()
             else:
                 assets = self.futu_connector.get_sync_assets()
-            self.account_value = float(assets.get("total_assets", self.account_value))
+            total_assets = float(assets.get("total_assets", self.account_value))
+            if total_assets > 0:
+                self.account_value = total_assets
+            else:
+                # Broker returned 0 (SIMULATE account unfunded or transient connection issue).
+                # Preserve the last known value to prevent a false 100% drawdown from
+                # triggering the circuit breaker and blocking all trade execution.
+                self._emit_structured(
+                    "broker_sync_zero_equity",
+                    kept_value=round(self.account_value, 2),
+                    reason="broker returned total_assets=0; preserving last known value",
+                )
         except Exception as exc:
             self.logger.warning("Asset sync failed: %s", exc)
 


### PR DESCRIPTION
## 本 PR 包含以下三項修復

### 1. 修復 SIMULATE 模式 broker 回傳零 equity 導致 circuit breaker 誤觸發（commit 94b8d55）

**問題根因：**
- Futu SIMULATE 帳戶未充資金時，`get_sync_assets()` 回傳 `total_assets=0`
- `_sync_broker_state()` 直接將 `account_value` 設為 0，回撤變成 100%，circuit breaker 每次觸發
- 所有 `_execute()` 呼叫立即 return，無任何交易可執行

**修復：** 只在 broker 回傳正值時更新 `account_value`，否則保留上次已知值並發出 `broker_sync_zero_equity` 結構化事件。

**測試：** `tests/test_circuit_breaker_zero_equity.py`（11 個測試）

---

### 2. Futu SDK 連線超時防護（commit 1ae7fc8）

**問題根因：**
- Futu SDK 的 `_connect_sync` 每 26 秒重試一次，共可持續 21 分鐘阻塞整個 launcher
- `_wait_for_opend()` TCP 層通過，但 Futu 協議握手失敗時無 wall-clock 上限

**修復：** `_safe_connector_connect()` 在 daemon thread 執行 SDK 連線，超過 `futu_connect_timeout_seconds`（預設 90 秒）後返回 False 進入降級模式。

**測試：** 新增 7 個測試至 `tests/test_opend_stability.py`（共 36 個）

---

### 3. _collect_only_cycle 逐 symbol 逾時隔離（commit 666593e）

**問題根因：**
- `asyncio.TimeoutError` 在 batch 層級被捕捉：一個 symbol 逾時，同一批次其餘 4 個 symbol 全部被跳過
- 在 v3_live.log 觀察到大量 `[IDLE_COLLECT] Batch timeout occurred, skipping current batch`（每 ~90 秒）

**修復：**
- 將 try/except 移至 symbol 層級，每個 symbol 獨立逾時處理
- 逾時從 15s 降為 10s（更快失敗，減少 IDLE 週期卡頓）
- 使用 `.get(sym)` 代替直接 dict 存取以防 KeyError
- 發出逾時/錯誤計數的 WARNING 摘要（`fetched=N timed_out=N errors=N / M symbols`）

**測試：** `tests/test_idle_collect.py`（12 個新測試）

---

## 測試結果

```
383 passed, 4 pre-existing failures (test_model_registry 隔離問題，非本 PR 引入), 1 skipped
```
