### PR TITLE
fix: 測試日誌污染 — 新增 KIRO_LOG_DIR 隔離機制

### DIFF
--- a/idle_task_scheduler.py
+++ b/idle_task_scheduler.py
@@ -32,6 +32,18 @@ if TYPE_CHECKING:
 
 # ── Logging ───────────────────────────────────────────────────────────────────
 
+def _get_idle_log_dir() -> Path:
+    """Return the log directory, honouring KIRO_LOG_DIR env var for test isolation."""
+    override = os.environ.get("KIRO_LOG_DIR")
+    if override:
+        p = Path(override)
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+    default = Path(__file__).parent / "logs"
+    default.mkdir(exist_ok=True)
+    return default
+
+
 def _build_idle_logger() -> logging.Logger:
     logger = logging.getLogger("kiro.idle_scheduler")
     if logger.handlers:
@@ -45,8 +57,7 @@ def _build_idle_logger() -> logging.Logger:
     logger.addHandler(console)
     try:
         from logging.handlers import RotatingFileHandler
-        log_dir = Path(__file__).parent / "logs"
-        log_dir.mkdir(exist_ok=True)
+        log_dir = _get_idle_log_dir()
         fh = RotatingFileHandler(
             log_dir / "idle_scheduler.log",
             maxBytes=5 * 1024 * 1024,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+import os
+import shutil
+import tempfile
+
 import requests  # noqa: F401 — must be imported before test_main_loop_trade_bridge.py stubs it
 
 collect_ignore = [
@@ -5,3 +9,23 @@ collect_ignore = [
     "test_risk_guard_net_assets.py",
     "test_data_manager.py",
 ]
+
+# ── Log isolation ─────────────────────────────────────────────────────────────
+# Redirect all test-process log files to a temp directory so pytest runs never
+# write to the production logs/ directory (v3_live.log, decisions.jsonl,
+# idle_scheduler.log).  The temp directory is removed when the session ends.
+
+_test_log_dir: str | None = None
+
+
+def pytest_configure(config: object) -> None:
+    global _test_log_dir
+    _test_log_dir = tempfile.mkdtemp(prefix="kiro-test-logs-")
+    os.environ["KIRO_LOG_DIR"] = _test_log_dir
+
+
+def pytest_unconfigure(config: object) -> None:
+    global _test_log_dir
+    if _test_log_dir:
+        shutil.rmtree(_test_log_dir, ignore_errors=True)
+        _test_log_dir = None

--- a/tests/test_log_dir_isolation.py
+++ b/tests/test_log_dir_isolation.py
@@ -1,0 +1,90 @@
+"""
+Tests for KIRO_LOG_DIR log-path isolation.
+
+Production log files (v3_live.log, decisions.jsonl, idle_scheduler.log) must
+never be written to during test runs.  The conftest.py sets KIRO_LOG_DIR before
+any test module is imported so every RotatingFileHandler uses the temp directory.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+
+# ── _get_log_dir helpers ──────────────────────────────────────────────────────
+
+class TestGetLogDir:
+    def test_default_is_repo_logs(self, tmp_path, monkeypatch):
+        """Without KIRO_LOG_DIR the function returns <project_root>/logs."""
+        monkeypatch.delenv("KIRO_LOG_DIR", raising=False)
+        from v3_pipeline.core.main_loop import _get_log_dir
+        result = _get_log_dir()
+        assert result.name == "logs"
+        assert result.is_dir()
+
+    def test_env_override_is_honoured(self, tmp_path, monkeypatch):
+        """With KIRO_LOG_DIR set, _get_log_dir returns that path."""
+        custom = tmp_path / "my_logs"
+        monkeypatch.setenv("KIRO_LOG_DIR", str(custom))
+        from v3_pipeline.core.main_loop import _get_log_dir
+        result = _get_log_dir()
+        assert result == custom
+        assert custom.is_dir()
+
+    def test_env_override_creates_directory(self, tmp_path, monkeypatch):
+        """_get_log_dir creates the directory if it does not exist yet."""
+        custom = tmp_path / "deep" / "nested" / "logs"
+        assert not custom.exists()
+        monkeypatch.setenv("KIRO_LOG_DIR", str(custom))
+        from v3_pipeline.core.main_loop import _get_log_dir
+        _get_log_dir()
+        assert custom.is_dir()
+
+
+class TestIdleGetLogDir:
+    def test_default_is_project_logs(self, tmp_path, monkeypatch):
+        """Without KIRO_LOG_DIR, idle logger uses <project_root>/logs."""
+        monkeypatch.delenv("KIRO_LOG_DIR", raising=False)
+        from idle_task_scheduler import _get_idle_log_dir
+        result = _get_idle_log_dir()
+        assert result.name == "logs"
+        assert result.is_dir()
+
+    def test_env_override_is_honoured(self, tmp_path, monkeypatch):
+        """With KIRO_LOG_DIR set, idle logger uses that path."""
+        custom = tmp_path / "idle_logs"
+        monkeypatch.setenv("KIRO_LOG_DIR", str(custom))
+        from idle_task_scheduler import _get_idle_log_dir
+        result = _get_idle_log_dir()
+        assert result == custom
+        assert custom.is_dir()
+
+
+# ── Conftest sets KIRO_LOG_DIR ────────────────────────────────────────────────
+
+class TestConftestLogIsolation:
+    def test_kiro_log_dir_is_set(self):
+        """conftest.pytest_configure sets KIRO_LOG_DIR to a temp directory."""
+        log_dir = os.environ.get("KIRO_LOG_DIR")
+        assert log_dir is not None, "KIRO_LOG_DIR must be set by conftest"
+        assert Path(log_dir).is_dir()
+
+    def test_kiro_log_dir_is_not_production(self):
+        """KIRO_LOG_DIR must not point at the production logs/ directory."""
+        log_dir = Path(os.environ.get("KIRO_LOG_DIR", ""))
+        prod_logs = Path(__file__).parent.parent / "logs"
+        assert log_dir != prod_logs, (
+            "KIRO_LOG_DIR points at the production logs directory — "
+            "test logs would pollute production"
+        )
+
+    def test_kiro_log_dir_is_temp(self):
+        """KIRO_LOG_DIR should be under the system temp directory."""
+        log_dir = Path(os.environ.get("KIRO_LOG_DIR", ""))
+        tmp = Path(tempfile.gettempdir())
+        assert log_dir.is_relative_to(tmp), (
+            f"Expected KIRO_LOG_DIR under {tmp}, got {log_dir}"
+        )

--- a/v3_pipeline/core/main_loop.py
+++ b/v3_pipeline/core/main_loop.py
@@ -23,6 +23,18 @@ from v3_pipeline.models.manager import DataPreparer, ModelManager
 from v3_pipeline.risk.manager import RiskController
 
 
+def _get_log_dir() -> Path:
+    """Return the log directory, honouring KIRO_LOG_DIR env var for test isolation."""
+    override = os.environ.get("KIRO_LOG_DIR")
+    if override:
+        p = Path(override)
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+    default = Path(__file__).parent.parent.parent / "logs"
+    default.mkdir(exist_ok=True)
+    return default
+
+
 def _build_structured_logger(name: str) -> logging.Logger:
     """Returns a logger that writes one JSON line per record to logs/decisions.jsonl."""
     logger = logging.getLogger(name)
@@ -31,8 +43,7 @@ def _build_structured_logger(name: str) -> logging.Logger:
     logger.setLevel(logging.INFO)
     try:
         from logging.handlers import RotatingFileHandler
-        log_dir = Path(__file__).parent.parent.parent / "logs"
-        log_dir.mkdir(exist_ok=True)
+        log_dir = _get_log_dir()
         handler = RotatingFileHandler(
             log_dir / "decisions.jsonl",
             maxBytes=10 * 1024 * 1024,
@@ -62,8 +73,7 @@ def _build_stderr_logger(name: str) -> logging.Logger:
     # Rotating file handler — logs/v3_live.log (10MB per file, 5 backups kept)
     try:
         from logging.handlers import RotatingFileHandler
-        log_dir = Path(__file__).parent.parent.parent / "logs"
-        log_dir.mkdir(exist_ok=True)
+        log_dir = _get_log_dir()
         rotating = RotatingFileHandler(
             log_dir / "v3_live.log",
             maxBytes=10 * 1024 * 1024,  # 10 MB


### PR DESCRIPTION
## 問題背景

測試執行時，凡是建立 LiveTradingLoop 或 IdleTaskScheduler 實例的測試，
都會直接寫入正式環境的 log 檔案（logs/v3_live.log、logs/decisions.jsonl、
logs/idle_scheduler.log），因為日誌路徑是以 __file__ 為基準寫死的。

在 logs/v3_live.log 中可見測試產生的記錄（Buffer[TSLA] size: 3 source=test），
在 logs/idle_scheduler.log 中也可見 test_session already running 的記錄。

## 修正方式

- v3_pipeline/core/main_loop.py：新增 _get_log_dir() helper，優先讀取 KIRO_LOG_DIR 環境變數；兩個 logger builder（_build_structured_logger、_build_stderr_logger）均改用此函式。
- idle_task_scheduler.py：新增 _get_idle_log_dir() helper，同樣優先讀取 KIRO_LOG_DIR；_build_idle_logger() 改用此函式。
- tests/conftest.py：新增 pytest_configure / pytest_unconfigure hooks，在任何測試模組被匯入之前即建立臨時目錄並設定 KIRO_LOG_DIR，測試結束後自動清除。
- tests/test_log_dir_isolation.py：驗證全部 helper 行為，以及 conftest 隔離機制是否正確套用（共 8 項測試，全部通過）。

## 測試結果

8 passed in 1.41s   (test_log_dir_isolation.py)
391 passed, 4 failed (完整套件 — 4 項 test_model_registry 失敗為既有問題，在 main 分支上同樣存在，與本 PR 無關)

## 測試計畫

- 測試隔離 8 項全部通過
- 完整套件無新增迴歸（391 passed）
- 確認 test_model_registry 4 項失敗為既有問題（在 clean main 上同樣失敗）
- 正式環境 logs/ 目錄在測試執行期間不會被寫入

🤖 Generated with Claude Code
