### PR TITLE
fix: route HK market to HK acc_id 14239754 (not US global target)

### DIFF
--- a/config.json
+++ b/config.json
@@ -67,7 +67,15 @@
     "target_acc_id": 18526451,
     "host": "127.0.0.1",
     "port": 11112,
-    "trd_env": "SIMULATE"
+    "trd_env": "SIMULATE",
+    "accounts": {
+      "HK": {
+        "target_acc_id": 14239754
+      },
+      "US": {
+        "target_acc_id": 18526451
+      }
+    }
   },
   "idle_scheduler": {
     "enabled": true,

--- a/tests/test_account_routing.py
+++ b/tests/test_account_routing.py
@@ -307,3 +307,31 @@ def test_load_runtime_config_env_overrides_per_market(tmp_path, monkeypatch):
 
     # Env var must win over config.json value
     assert conn.config_market_accounts.get("HK") == 55551111
+
+
+def test_hk_not_using_us_global_acc_id_when_accounts_configured(tmp_path):
+    """Regression: config.json with futu.accounts must route HK to HK acc_id,
+    not fall back to the global target_acc_id (which is the US account)."""
+    cfg_data = {
+        "futu": {
+            "target_acc_id": 18526451,   # US account as global target
+            "accounts": {
+                "HK": {"target_acc_id": 14239754},
+                "US": {"target_acc_id": 18526451},
+            },
+        }
+    }
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps(cfg_data), encoding="utf-8")
+
+    conn = FutuConnector.__new__(FutuConnector)
+    conn.config = FutuConfig()
+    conn.config_market_accounts = {}
+    conn.account_ids = {}
+    conn.logger = MagicMock()
+
+    conn._load_runtime_config(str(p))
+
+    assert conn._account_kwargs_for_market("HK") == {"acc_id": 14239754}, \
+        "HK must use 14239754, not the global US target_acc_id 18526451"
+    assert conn._account_kwargs_for_market("US") == {"acc_id": 18526451}


### PR DESCRIPTION
## Summary

- `config.json` was missing `futu.accounts` section, causing `_account_kwargs_for_market("HK")` to fall back to the global `target_acc_id=18526451` (US account)
- This produced `Nonexisting acc_id 18526451` errors on every HK `position_list_query` cycle
- Fix: add `futu.accounts.HK.target_acc_id=14239754` and `futu.accounts.US.target_acc_id=18526451` to `config.json`

## Test plan

- [x] `test_hk_not_using_us_global_acc_id_when_accounts_configured` — new regression test added to `tests/test_account_routing.py`
- [x] All 17 `tests/test_account_routing.py` tests pass in isolated worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)