### PR TITLE
fix: route state.json I/O through state_store (atomic write + recovery)

### DIFF
--- a/tests/test_state_store_atomic.py
+++ b/tests/test_state_store_atomic.py
@@ -1,0 +1,166 @@
+"""Acceptance tests for state_store single-entrypoint hardening.
+
+Covers:
+- Corrupted JSON falls back to default state without crashing
+- Missing keys are filled from defaults
+- short_positions and account_routing survive a round-trip
+- save() uses tmp + os.replace (atomic write)
+- main_loop._execute() does not open state.json directly
+"""
+
+import json
+import os
+import time
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import state_store as ss
+
+
+# ── load() resilience ─────────────────────────────────────────────────────────
+
+
+def test_load_corrupted_json_returns_default(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    state_file.write_text("{invalid json{{", encoding="utf-8")
+    monkeypatch.setattr(ss, "STATE_PATH", str(state_file))
+
+    result = ss.load()
+    assert result["positions"] == {}
+    assert result["circuit_broken"] is False
+    assert "daily_pnl" in result
+
+
+def test_load_missing_file_returns_default(tmp_path, monkeypatch):
+    monkeypatch.setattr(ss, "STATE_PATH", str(tmp_path / "nonexistent.json"))
+    result = ss.load()
+    assert result["positions"] == {}
+    assert result["daily_trades"] == 0
+
+
+def test_load_missing_keys_filled_from_defaults(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"date": str(date.today()), "daily_pnl": 99.0}), encoding="utf-8")
+    monkeypatch.setattr(ss, "STATE_PATH", str(state_file))
+
+    result = ss.load()
+    assert result["daily_pnl"] == 99.0
+    assert "positions" in result
+    assert "last_orders" in result
+
+
+def test_load_preserves_short_positions(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    payload = {
+        "date": str(date.today()),
+        "daily_pnl": 0.0,
+        "daily_trades": 0,
+        "consecutive_errors": 0,
+        "circuit_broken": False,
+        "circuit_break_time": None,
+        "last_orders": {},
+        "positions": {"US.TSLA": 10},
+        "short_positions": {"US.NVDA": 5},
+        "total_invested": 0.0,
+    }
+    state_file.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(ss, "STATE_PATH", str(state_file))
+
+    result = ss.load()
+    assert result["short_positions"]["US.NVDA"] == 5
+    assert result["positions"]["US.TSLA"] == 10
+
+
+def test_load_preserves_account_routing(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    routing = {"account_routing": {"HK": {"resolved_acc_id": 14239754, "source": "config"}}}
+    payload = {
+        "date": str(date.today()),
+        "daily_pnl": 0.0,
+        "daily_trades": 0,
+        "consecutive_errors": 0,
+        "circuit_broken": False,
+        "circuit_break_time": None,
+        "last_orders": {},
+        "positions": {},
+        "total_invested": 0.0,
+        **routing,
+    }
+    state_file.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(ss, "STATE_PATH", str(state_file))
+
+    result = ss.load()
+    assert result["account_routing"]["HK"]["resolved_acc_id"] == 14239754
+
+
+# ── save() atomic write ───────────────────────────────────────────────────────
+
+
+def test_save_uses_atomic_replace(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(ss, "STATE_PATH", str(state_file))
+
+    replaced_calls = []
+    original_replace = os.replace
+
+    def spy_replace(src, dst):
+        replaced_calls.append((src, dst))
+        return original_replace(src, dst)
+
+    with patch("os.replace", side_effect=spy_replace):
+        ss.save({"positions": {}, "daily_pnl": 0.0})
+
+    assert len(replaced_calls) == 1
+    src, dst = replaced_calls[0]
+    assert src.endswith(".tmp")
+    assert dst == str(state_file)
+
+
+def test_save_roundtrip_short_positions(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(ss, "STATE_PATH", str(state_file))
+
+    state = ss.load()
+    state["short_positions"] = {"0005.HK": 200}
+    state["account_routing"] = {"HK": {"resolved_acc_id": 14239754}}
+    ss.save(state)
+
+    reloaded = ss.load()
+    assert reloaded["short_positions"]["0005.HK"] == 200
+    assert reloaded["account_routing"]["HK"]["resolved_acc_id"] == 14239754
+
+
+def test_save_no_tmp_file_left_behind(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(ss, "STATE_PATH", str(state_file))
+
+    ss.save({"positions": {}, "daily_pnl": 0.0})
+
+    tmp = tmp_path / "state.json.tmp"
+    assert not tmp.exists(), "tmp file must be cleaned up after atomic replace"
+
+
+# ── main_loop.py does not bypass state_store ─────────────────────────────────
+
+
+def test_main_loop_execute_no_direct_state_json_open():
+    """_execute() must not call open() with 'state.json' directly."""
+    src = Path("v3_pipeline/core/main_loop.py").read_text(encoding="utf-8")
+    # Allow only state_store usage; reject direct open("...state.json...") or open(state_file
+    import re
+    # Look for open( calls that reference state_file or state.json (not in comments)
+    lines = src.splitlines()
+    violations = []
+    for lineno, line in enumerate(lines, 1):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if "open(" in stripped and ("state.json" in stripped or "state_file" in stripped):
+            violations.append(f"line {lineno}: {stripped}")
+    assert violations == [], (
+        "main_loop.py must use state_store, not open() state.json directly:\n"
+        + "\n".join(violations)
+    )

--- a/v3_pipeline/core/main_loop.py
+++ b/v3_pipeline/core/main_loop.py
@@ -1765,8 +1765,6 @@ class LiveTradingLoop:
     def _sync_broker_state(self) -> None:
         import os as _os
         import json as _json
-        workspace_root = _os.path.abspath(_os.path.join(_os.path.dirname(__file__), "..", "..", ".."))
-        state_file = _os.path.join(workspace_root, "state.json")
 
         # 1. Sync total account value across all active market accounts.
         # When both HK and US trade contexts are live, sum assets from each so that
@@ -1847,28 +1845,26 @@ class LiveTradingLoop:
                 self.logger.warning("Broker returned empty positions DataFrame")
         except Exception as exc:
             self.logger.warning("Broker position sync failed: %s — falling back to state.json", exc)
-            # Fallback: try state.json
-            if _os.path.exists(state_file):
-                try:
-                    with open(state_file, "r") as f:
-                        state = _json.load(f)
-                    positions_map = state.get("positions", {})
-                    for symbol in self.symbols:
-                        for key, qty in positions_map.items():
-                            norm = key.replace("US.", "").replace(".HK", "HK")
-                            if symbol.replace(".HK", "HK") == norm or symbol == key:
-                                self.position_qty_by_symbol[symbol] = max(0, int(qty))
-                                break
-                    short_positions_map = state.get("short_positions", {})
-                    for symbol in self.symbols:
-                        for key, sqty in short_positions_map.items():
-                            norm = key.replace("US.", "").replace(".HK", "HK")
-                            if symbol.replace(".HK", "HK") == norm or symbol == key:
-                                self.short_position_qty_by_symbol[symbol] = max(0, int(sqty))
-                                break
-                    self.logger.info("Fallback: positions synced from state.json")
-                except Exception:
-                    pass
+            try:
+                import state_store as _ss
+                state = _ss.load()
+                positions_map = state.get("positions", {})
+                for symbol in self.symbols:
+                    for key, qty in positions_map.items():
+                        norm = key.replace("US.", "").replace(".HK", "HK")
+                        if symbol.replace(".HK", "HK") == norm or symbol == key:
+                            self.position_qty_by_symbol[symbol] = max(0, int(qty))
+                            break
+                short_positions_map = state.get("short_positions", {})
+                for symbol in self.symbols:
+                    for key, sqty in short_positions_map.items():
+                        norm = key.replace("US.", "").replace(".HK", "HK")
+                        if symbol.replace(".HK", "HK") == norm or symbol == key:
+                            self.short_position_qty_by_symbol[symbol] = max(0, int(sqty))
+                            break
+                self.logger.info("Fallback: positions synced from state.json")
+            except Exception:
+                pass
 
         # Mirror flat position dicts into per-market MarketContext objects so callers
         # have an explicit market-scoped view of positions alongside the global dicts.
@@ -2028,12 +2024,9 @@ class LiveTradingLoop:
 
         # Persist positions into state.json to avoid repeated SELL/BUY after restart
         # Works in both paper (NO_FUTU=1) and real/SIM trading (NO_FUTU=0) modes
-        state_file = _os.path.join(_os.path.dirname(__file__), "..", "..", "state.json")
         try:
-            state: dict = {}
-            if _os.path.exists(state_file):
-                with open(state_file, "r", encoding="utf-8") as f:
-                    state = _json.load(f) or {}
+            import state_store as _ss
+            state = _ss.load()
 
             code, _ = self.futu_connector.resolve_symbol(symbol)
             state["date"] = datetime.now(timezone.utc).date().isoformat()
@@ -2062,8 +2055,7 @@ class LiveTradingLoop:
                 except Exception:
                     pass
 
-            with open(state_file, "w", encoding="utf-8") as f:
-                f.write(_json.dumps(state, ensure_ascii=False, indent=2) + "\n")
+            _ss.save(state)
         except Exception as exc:
             self.logger.warning("Failed to persist state.json: %s", exc)
 


### PR DESCRIPTION
## Summary

- `main_loop.py` was calling `open("state.json")` directly for both broker-fallback position reads and post-trade persistence writes, bypassing `state_store`'s atomic write and corrupted-file recovery
- `_sync_broker_state()` fallback now calls `state_store.load()` — handles missing/corrupted file gracefully without `if os.path.exists()` guard
- `_execute()` persistence now calls `state_store.load()` + `state_store.save()` — atomic via tmp+`os.replace`, never produces a truncated `state.json`

## Test plan

- [x] `tests/test_state_store_atomic.py` (new): corrupted JSON → default, missing keys → defaults, `short_positions`/`account_routing` round-trip, atomic replace spy, no tmp file left behind, structural check that `main_loop.py` has no direct `open(state.json)`
- [x] `tests/test_state_store_timestamp.py`: 1 existing test still passes
- [x] `tests/test_main_loop_trade_bridge.py`: 22 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)