### PR TITLE
fix: broker order placed before position mutation (LIVE mode ordering)

### DIFF
--- a/tests/test_live_execution_ordering.py
+++ b/tests/test_live_execution_ordering.py
@@ -1,0 +1,232 @@
+"""Acceptance tests for live-execution-state-machine refactor.
+
+Acceptance criteria:
+- broker exception: position dict completely unchanged
+- auto_trade=False: decision is recorded (not silently discarded)
+- paper_trading=True: FutuConnector.place_order() is never called
+- BUY and SELL both go through the same dispatch_execution boundary
+"""
+
+import sys
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import pandas as pd
+import pytest
+
+sys.modules.setdefault("requests", SimpleNamespace(post=lambda *a, **kw: None))
+sys.modules.setdefault(
+    "v3_pipeline.models.manager",
+    SimpleNamespace(
+        DataPreparer=lambda **kw: SimpleNamespace(
+            lookback=2,
+            target_col="Close",
+            is_fitted=True,
+            feature_columns=None,
+            fit_transform=lambda frame: frame,
+        ),
+        ModelManager=object,
+    ),
+)
+
+from v3_pipeline.core.main_loop import LiveConfig, LiveTradingLoop
+
+
+# ── Minimal stubs ─────────────────────────────────────────────────────────────
+
+
+class _FakeConnector:
+    """Configurable stub for FutuConnector."""
+
+    def __init__(self, place_order_raises=None):
+        self._raise = place_order_raises
+        self.place_order_calls = []
+
+    class config:
+        market_prefix = "US"
+
+    config_market_accounts = {}
+    account_ids = {}
+
+    def connect(self): pass
+    def close(self): pass
+    def heartbeat(self): return True
+    def get_sync_assets(self): return {"total_assets": 100_000.0}
+    def get_sync_positions(self): return pd.DataFrame(columns=["code", "qty", "can_sell_qty"])
+    def get_latest_quote(self, symbol):
+        return {"Date": pd.Timestamp("2026-01-01"), "Open": 100.0, "High": 101.0,
+                "Low": 99.0, "Close": 100.0, "Volume": 10000, "data_source": "test", "symbol": symbol}
+
+    def get_order_reference_price(self, _sym, _side, fallback_price):
+        return fallback_price
+
+    def get_open_orders(self):
+        return pd.DataFrame([])
+
+    def place_order(self, symbol, qty, side, price):
+        self.place_order_calls.append((symbol, qty, side, price))
+        if self._raise:
+            raise self._raise
+
+    def validate_trading_ready(self): pass
+    def _resolved_trd_env(self): return "SIMULATE"
+
+
+class _FakeModelManager:
+    data_preparer = SimpleNamespace(
+        lookback=2, target_col="Close", is_fitted=True, feature_columns=None,
+        fit_transform=lambda frame: frame,
+    )
+
+    def predict(self, *a, **kw): return 0.0
+    def predict_pattern(self, *a, **kw): return {"pattern": "Unknown", "confidence": 0.0, "probs": {}}
+
+
+class _FakeRisk:
+    config = SimpleNamespace(max_daily_loss_fraction=1.0)
+    def circuit_breaker_triggered(self, *a, **kw): return False
+    def allow_trade_with_ror(self, *a, **kw): return True
+    def allow_daily_loss(self, *a, **kw): return True
+    def allow_trade_with_var_cvar(self, *a, **kw): return True
+    def estimate_cvar_95(self, *a, **kw): return -0.05
+
+
+def _make_loop(auto_trade=True, paper_trading=False, connector=None) -> LiveTradingLoop:
+    cfg = LiveConfig(
+        symbol="TSLA",
+        symbols_list=["TSLA"],
+        prediction_threshold=0.01,
+        prediction_thresholds={"TSLA": 0.01},
+        auto_trade=auto_trade,
+        paper_trading=paper_trading,
+        log_trade_decisions=True,
+        polling_seconds=1,
+    )
+    loop = LiveTradingLoop(
+        model_manager=_FakeModelManager(),
+        risk_controller=_FakeRisk(),
+        futu_connector=connector or _FakeConnector(),
+        data_manager=None,
+        feature_generator=SimpleNamespace(generate=lambda f: f),
+        config=cfg,
+    )
+    loop.alpha_engine = SimpleNamespace(select_features=lambda _sym, f: f)
+    return loop
+
+
+# ── Test: broker exception does NOT mutate position dict ─────────────────────
+
+
+def test_live_buy_broker_failure_position_unchanged():
+    connector = _FakeConnector(place_order_raises=RuntimeError("broker down"))
+    loop = _make_loop(auto_trade=True, paper_trading=False, connector=connector)
+    loop.position_qty_by_symbol["TSLA"] = 0
+
+    loop._execute("TSLA", "BUY", qty=10, price=100.0, reason="test")
+
+    assert loop.position_qty_by_symbol["TSLA"] == 0, (
+        "BUY: broker failure must leave position unchanged"
+    )
+
+
+def test_live_sell_broker_failure_position_unchanged():
+    connector = _FakeConnector(place_order_raises=RuntimeError("broker down"))
+    loop = _make_loop(auto_trade=True, paper_trading=False, connector=connector)
+    loop.position_qty_by_symbol["TSLA"] = 50
+
+    loop._execute("TSLA", "SELL", qty=50, price=100.0, reason="test")
+
+    assert loop.position_qty_by_symbol["TSLA"] == 50, (
+        "SELL: broker failure must leave position unchanged"
+    )
+
+
+def test_live_buy_success_mutates_position_after_broker():
+    connector = _FakeConnector()
+    loop = _make_loop(auto_trade=True, paper_trading=False, connector=connector)
+    loop.position_qty_by_symbol["TSLA"] = 0
+
+    with patch.object(loop, "_append_decision_trace"):
+        loop._execute("TSLA", "BUY", qty=10, price=100.0, reason="test")
+
+    assert loop.position_qty_by_symbol["TSLA"] == 10
+    assert len(connector.place_order_calls) == 1
+
+
+# ── Test: auto_trade=False records simulated decision ────────────────────────
+
+
+def test_auto_trade_false_records_decision_not_silent():
+    loop = _make_loop(auto_trade=False)
+    loop.position_qty_by_symbol["TSLA"] = 0
+
+    decisions = []
+    with patch.object(loop, "_append_decision_trace", side_effect=decisions.append):
+        loop._execute("TSLA", "BUY", qty=10, price=100.0, reason="test_simulate")
+
+    assert len(decisions) == 1, "SIMULATE mode must call _append_decision_trace once"
+    assert decisions[0]["mode"] == "simulate"
+    assert loop.position_qty_by_symbol["TSLA"] == 0, "SIMULATE must not mutate position"
+
+
+def test_auto_trade_false_sell_records_decision_not_silent():
+    loop = _make_loop(auto_trade=False)
+    loop.position_qty_by_symbol["TSLA"] = 20
+
+    decisions = []
+    with patch.object(loop, "_append_decision_trace", side_effect=decisions.append):
+        loop._execute("TSLA", "SELL", qty=20, price=100.0, reason="test_simulate")
+
+    assert len(decisions) == 1
+    assert decisions[0]["mode"] == "simulate"
+    assert loop.position_qty_by_symbol["TSLA"] == 20, "SIMULATE SELL must not mutate position"
+
+
+# ── Test: paper_trading=True never calls place_order ─────────────────────────
+
+
+def test_paper_trading_buy_does_not_call_place_order():
+    connector = _FakeConnector()
+    loop = _make_loop(auto_trade=True, paper_trading=True, connector=connector)
+    loop.position_qty_by_symbol["TSLA"] = 0
+
+    loop._execute("TSLA", "BUY", qty=10, price=100.0, reason="test_paper")
+
+    assert connector.place_order_calls == [], "PAPER mode must never call place_order()"
+    assert loop.position_qty_by_symbol["TSLA"] == 10, "PAPER BUY must still mutate position locally"
+
+
+def test_paper_trading_sell_does_not_call_place_order():
+    connector = _FakeConnector()
+    loop = _make_loop(auto_trade=True, paper_trading=True, connector=connector)
+    loop.position_qty_by_symbol["TSLA"] = 30
+
+    loop._execute("TSLA", "SELL", qty=30, price=100.0, reason="test_paper")
+
+    assert connector.place_order_calls == [], "PAPER mode must never call place_order()"
+    assert loop.position_qty_by_symbol["TSLA"] == 0
+
+
+# ── Test: broker is called BEFORE position is mutated (ordering) ─────────────
+
+
+def test_live_broker_called_before_position_mutated():
+    """Verify broker.place_order() is called while position is still at 0."""
+    position_at_call_time = {}
+
+    def tracking_place_order(sym, qty, side, price):
+        position_at_call_time["before"] = loop.position_qty_by_symbol.get("TSLA", 0)
+
+    connector = _FakeConnector()
+    connector.place_order = tracking_place_order
+    loop = _make_loop(auto_trade=True, paper_trading=False, connector=connector)
+    loop.position_qty_by_symbol["TSLA"] = 0
+
+    with patch.object(loop, "_append_decision_trace"):
+        loop._execute("TSLA", "BUY", qty=10, price=100.0, reason="ordering_test")
+
+    assert position_at_call_time["before"] == 0, (
+        "Position must still be 0 when place_order() is called (broker first, mutate after)"
+    )
+    assert loop.position_qty_by_symbol["TSLA"] == 10, "Position must be updated after broker success"

--- a/v3_pipeline/core/main_loop.py
+++ b/v3_pipeline/core/main_loop.py
@@ -1908,8 +1908,15 @@ class LiveTradingLoop:
         )
 
     def _execute(self, symbol: str, side: str, qty: int, price: float, reason: str, indicators: dict | None = None, prediction: float | None = None) -> None:
-        # Guard: 所有副作用（position mutation + 下單）必須喺同一個 auto_trade block 內
-        if not self.config.auto_trade:
+        from v3_pipeline.execution.state_machine import (
+            PositionDelta, dispatch_execution, resolve_execution_mode, ExecutionMode, simulate_only,
+        )
+        mode = resolve_execution_mode(self.config.auto_trade, self.config.paper_trading)
+        if mode == ExecutionMode.SIMULATE:
+            simulate_only(
+                PositionDelta(symbol=symbol, side=side, qty=qty, fill_price=price, reason=reason),
+                log_decision=self._append_decision_trace,
+            )
             return
 
         # 2026-04-24 Fix: Double-check broker position before placing order.
@@ -1958,43 +1965,37 @@ class LiveTradingLoop:
                 )
                 return
 
-            self.position_qty_by_symbol[symbol] += qty
+        # Route through execution state machine: PAPER fills locally, LIVE places broker order first
+        delta = PositionDelta(symbol=symbol, side=side, qty=qty, fill_price=fill_price, reason=reason)
+        accepted = dispatch_execution(
+            delta,
+            mode,
+            self.position_qty_by_symbol,
+            place_order_fn=(lambda sym, q, s, p: self.futu_connector.place_order(sym, q, s, p))
+                if mode == ExecutionMode.LIVE else None,
+            log_decision=self._append_decision_trace,
+        )
+
+        if not accepted:
+            # LIVE broker rejection — position state is unchanged, do not log or persist
+            return
+
+        # Position was accepted (PAPER fill or LIVE broker accepted) — update secondary state
+        if side == "BUY":
             self.highest_price_since_entry_by_symbol[symbol] = fill_price
             self.entry_price_by_symbol[symbol] = fill_price
             self.cycles_since_buy_by_symbol[symbol] = 0
-            # v2: Store entry RSI for RSI-gated take profit at exit
             if indicators:
                 self.entry_rsi_by_symbol[symbol] = float(indicators.get("RSI_14", 50.0))
-        if side == "SELL":
-            self.position_qty_by_symbol[symbol] = max(0, self.position_qty_by_symbol[symbol] - qty)
-            if self.position_qty_by_symbol[symbol] == 0:
+        elif side == "SELL":
+            if self.position_qty_by_symbol.get(symbol, 0) == 0:
                 self.highest_price_since_entry_by_symbol[symbol] = 0.0
                 self.bars_held_by_symbol[symbol] = 0
                 self.cycles_since_buy_by_symbol[symbol] = 999999
-                # 2026-04-24 Fix: Mark last sell time to prevent immediate re-sync
                 self._last_sell_time_by_symbol[symbol] = datetime.now(timezone.utc)
 
-        if self.config.paper_trading:
+        if mode == ExecutionMode.PAPER:
             self.logger.info("PAPER_ORDER %s %s qty=%d limit=%.4f type=NORMAL", symbol, side, qty, fill_price)
-        else:
-            try:
-                self.futu_connector.place_order(symbol, qty, side, fill_price)
-            except Exception as exc:
-                self.logger.error("[%s] Order failed: %s — reverting local state", symbol, exc)
-                # Revert local position state on failure
-                if side == "BUY":
-                    self.position_qty_by_symbol[symbol] = max(0, self.position_qty_by_symbol.get(symbol, 0) - qty)
-                else:
-                    self.position_qty_by_symbol[symbol] += qty
-                self._append_decision_trace({
-                    "ts": datetime.now(timezone.utc).isoformat(),
-                    "symbol": symbol,
-                    "action": "ORDER_FAILED_REVERTED",
-                    "side": side,
-                    "qty": qty,
-                    "error": str(exc),
-                })
-                return  # Graceful exit — do not crash
 
         self.logger.info("EXEC %s %s qty=%d fill=%.4f reason=%s", symbol, side, qty, fill_price, reason)
         self._emit_structured(


### PR DESCRIPTION
## Summary

- `_execute()` was mutating position state BEFORE calling the broker, then reverting on failure — leaving a window where local state diverged from broker state on any partial failure
- Replace the pre-mutate-then-revert pattern with `dispatch_execution()` from `state_machine.py`:
  - **SIMULATE** (`auto_trade=False`): `simulate_only()` records the decision — no longer a silent early return
  - **PAPER**: local fill applied, `place_order()` never called
  - **LIVE**: broker called first; position mutated only after broker accepts — exception leaves position completely unchanged
- Secondary state (`entry_price`, `highest_price`, `last_sell_time`, etc.) updated only after `dispatch_execution()` returns `True`

## Test plan

- [x] `tests/test_live_execution_ordering.py` (new, 8 tests): broker failure → position unchanged (BUY+SELL), SIMULATE records decision, PAPER never calls `place_order`, broker-before-mutation ordering
- [x] `tests/test_main_loop_trade_bridge.py`: 22 existing tests still pass
- [x] `tests/test_execution_state_machine.py`: 25 existing state machine tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)