### PR TITLE
fix: prevent duplicate launcher with runtime instance lock (PID file + stale detection)

### DIFF
--- a/tests/test_runtime_lock.py
+++ b/tests/test_runtime_lock.py
@@ -1,0 +1,166 @@
+"""Acceptance tests for runtime single-instance lock.
+
+Acceptance criteria:
+- Second launcher cannot enter live trading loop when lock is held
+- Stale PID lock (process no longer alive) can be recovered
+- Lock acquisition writes current PID to pid file
+- Lock release removes the pid file
+- Context manager form works (acquire/release)
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from v3_pipeline.core.runtime_lock import RuntimeLock
+
+
+# ── Acquire / release basics ──────────────────────────────────────────────────
+
+
+def test_acquire_creates_pid_file(tmp_path):
+    lock = RuntimeLock(pid_file=tmp_path / "test.pid")
+    assert lock.acquire()
+    assert (tmp_path / "test.pid").exists()
+    lock.release()
+
+
+def test_acquire_writes_current_pid(tmp_path):
+    lock = RuntimeLock(pid_file=tmp_path / "test.pid")
+    lock.acquire()
+    written = int((tmp_path / "test.pid").read_text().strip())
+    assert written == os.getpid()
+    lock.release()
+
+
+def test_release_removes_pid_file(tmp_path):
+    lock = RuntimeLock(pid_file=tmp_path / "test.pid")
+    lock.acquire()
+    lock.release()
+    assert not (tmp_path / "test.pid").exists()
+
+
+def test_release_is_idempotent(tmp_path):
+    lock = RuntimeLock(pid_file=tmp_path / "test.pid")
+    lock.acquire()
+    lock.release()
+    lock.release()  # second call must not raise
+
+
+# ── Second launcher blocked ───────────────────────────────────────────────────
+
+
+def test_second_launcher_blocked_when_lock_held(tmp_path):
+    """First lock acquired; second acquire must return False."""
+    lock1 = RuntimeLock(pid_file=tmp_path / "test.pid")
+    lock2 = RuntimeLock(pid_file=tmp_path / "test.pid")
+
+    assert lock1.acquire()
+    # Simulate lock2 checking: current process (holding lock1) is alive
+    assert lock2.acquire() is False, "Second launcher must be blocked"
+    lock1.release()
+
+
+def test_second_launcher_blocked_returns_false_not_raises(tmp_path):
+    lock1 = RuntimeLock(pid_file=tmp_path / "test.pid")
+    lock2 = RuntimeLock(pid_file=tmp_path / "test.pid")
+    lock1.acquire()
+    result = lock2.acquire()
+    assert result is False
+    lock1.release()
+
+
+# ── Stale PID recovery ────────────────────────────────────────────────────────
+
+
+def test_stale_pid_lock_can_be_recovered(tmp_path):
+    """PID file with a dead process should be overwritten (stale recovery)."""
+    pid_file = tmp_path / "test.pid"
+    dead_pid = 999999999  # Almost certainly not a real process
+    pid_file.write_text(str(dead_pid))
+
+    lock = RuntimeLock(pid_file=pid_file)
+    assert lock.acquire(), "Stale lock with dead PID must be recoverable"
+    assert int(pid_file.read_text().strip()) == os.getpid()
+    lock.release()
+
+
+def test_missing_pid_file_is_treated_as_no_lock(tmp_path):
+    pid_file = tmp_path / "nonexistent.pid"
+    lock = RuntimeLock(pid_file=pid_file)
+    assert lock.acquire()
+    lock.release()
+
+
+def test_corrupted_pid_file_is_treated_as_stale(tmp_path):
+    pid_file = tmp_path / "test.pid"
+    pid_file.write_text("not_a_number")
+    lock = RuntimeLock(pid_file=pid_file)
+    assert lock.acquire(), "Corrupted PID file must be treated as stale"
+    lock.release()
+
+
+# ── Context manager ───────────────────────────────────────────────────────────
+
+
+def test_context_manager_acquires_and_releases(tmp_path):
+    pid_file = tmp_path / "test.pid"
+    lock = RuntimeLock(pid_file=pid_file)
+    assert lock.acquire()
+    with lock:
+        assert pid_file.exists()
+    assert not pid_file.exists()
+
+
+def test_context_manager_releases_on_exception(tmp_path):
+    pid_file = tmp_path / "test.pid"
+    lock = RuntimeLock(pid_file=pid_file)
+    lock.acquire()
+    try:
+        with lock:
+            raise RuntimeError("simulated crash")
+    except RuntimeError:
+        pass
+    assert not pid_file.exists(), "Lock must be released even when exception is raised"
+
+
+# ── v3_launcher integration ───────────────────────────────────────────────────
+
+
+def test_run_kiro_v35_exits_early_when_lock_already_held(tmp_path):
+    """run_kiro_v35 must return early without entering the live loop when locked."""
+    import sys
+    from types import SimpleNamespace
+
+    # Pre-write a PID file with the CURRENT process's PID so it looks like
+    # another (alive) launcher is running.
+    pid_file = tmp_path / "v3_pid.txt"
+    pid_file.write_text(str(os.getpid()))
+
+    import v3_launcher as launcher_mod
+
+    loop_started = []
+
+    with (
+        patch.object(
+            sys.modules["v3_pipeline.core.runtime_lock"],
+            "_DEFAULT_PID_FILE",
+            pid_file,
+        ),
+        patch("v3_launcher.build_live_config", side_effect=lambda *a: loop_started.append(True)),
+    ):
+        from v3_pipeline.core.runtime_lock import RuntimeLock as RL
+
+        # Patch RuntimeLock to use our tmp pid_file
+        original_init = RL.__init__
+
+        def patched_init(self, pid_file=None):
+            original_init(self, pid_file=pid_file or str(tmp_path / "v3_pid.txt"))
+
+        with patch.object(RL, "__init__", patched_init):
+            launcher_mod.run_kiro_v35(config_path="config.json")
+
+    assert loop_started == [], "build_live_config must not be called when lock is already held"

--- a/v3_launcher.py
+++ b/v3_launcher.py
@@ -719,6 +719,19 @@ async def _run_market_aware(
 
 
 def run_kiro_v35(*, dry_run: bool = False, once: bool = False, config_path: str = "config.json") -> None:
+    from v3_pipeline.core.runtime_lock import RuntimeLock
+    import logging as _logging
+    _startup_log = _logging.getLogger("v3_launcher")
+    lock = RuntimeLock()
+    if not lock.acquire():
+        existing = lock._read_existing_pid()
+        _startup_log.error(
+            "Another launcher instance is already running (PID %s). "
+            "Refusing to start a second live trading loop.",
+            existing,
+        )
+        return
+
     disable_trade = dry_run or once
     live_cfg = build_live_config(config_path)
     if disable_trade:
@@ -844,6 +857,7 @@ def run_kiro_v35(*, dry_run: bool = False, once: bool = False, config_path: str 
     # Cleanup on normal exit or after max attempts
     loop._archive_market_data()
     loop.futu_connector.close()
+    lock.release()
 
 
 if __name__ == "__main__":

--- a/v3_pipeline/core/runtime_lock.py
+++ b/v3_pipeline/core/runtime_lock.py
@@ -1,0 +1,78 @@
+"""Runtime instance guard using a PID file with stale-process detection.
+
+Prevents two live trading launchers from running simultaneously, which would
+cause double-order and duplicate position-mutation bugs.
+
+Usage::
+
+    lock = RuntimeLock()
+    if not lock.acquire():
+        sys.exit("Another launcher is already running.")
+    try:
+        run_live_loop()
+    finally:
+        lock.release()
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_DEFAULT_PID_FILE = Path(__file__).parent.parent.parent / "v3_pid.txt"
+
+
+class RuntimeLock:
+    """File-based single-instance guard with stale-PID recovery."""
+
+    def __init__(self, pid_file: "Path | str | None" = None) -> None:
+        self.pid_file = Path(pid_file) if pid_file else _DEFAULT_PID_FILE
+        self._acquired = False
+
+    def _read_existing_pid(self) -> "int | None":
+        try:
+            return int(self.pid_file.read_text().strip())
+        except (FileNotFoundError, ValueError, OSError):
+            return None
+
+    @staticmethod
+    def _is_process_alive(pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            # Process exists but we lack permission to signal it — treat as alive.
+            return True
+
+    def acquire(self) -> bool:
+        """Try to acquire the runtime lock.
+
+        Returns True if the lock was acquired (no live owner or stale PID).
+        Returns False if another live process already holds the lock.
+        """
+        existing_pid = self._read_existing_pid()
+        if existing_pid is not None and self._is_process_alive(existing_pid):
+            return False
+        # Stale lock or no lock file — write our PID.
+        try:
+            self.pid_file.write_text(str(os.getpid()))
+        except OSError:
+            return False
+        self._acquired = True
+        return True
+
+    def release(self) -> None:
+        """Release the lock (best-effort; safe to call multiple times)."""
+        if self._acquired:
+            try:
+                self.pid_file.unlink(missing_ok=True)
+            except OSError:
+                pass
+            self._acquired = False
+
+    def __enter__(self) -> "RuntimeLock":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.release()


### PR DESCRIPTION
## Summary

- Two simultaneous `v3_launcher.py` processes were observed in production (PIDs 9970 and 12924), causing double-cycle and double-order bugs
- Add `v3_pipeline/core/runtime_lock.py`: PID file guard with stale-process detection (`os.kill(pid, 0)`); corrupted/missing PID file treated as stale and recoverable
- `run_kiro_v35()` acquires the lock before setup; returns early with an error log if another live launcher holds the lock
- `lock.release()` called on normal exit and supports context-manager form

## Test plan

- [x] `tests/test_runtime_lock.py` (new, 12 tests): acquire/release lifecycle, second launcher blocked, stale-PID recovery, corrupted PID file, context manager release-on-exception, launcher integration test (exits before `build_live_config` when locked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)