### PR TITLE
refactor: MarketDataSnapshot for immutable per-cycle quote isolation

### DIFF
--- a/tests/test_market_data_snapshot.py
+++ b/tests/test_market_data_snapshot.py
@@ -1,0 +1,165 @@
+"""Acceptance tests for MarketDataSnapshot.
+
+Acceptance criteria:
+- Symbols with fresh cache entries are in the snapshot
+- Symbols with stale/missing cache entries produce a per-symbol miss reason
+- Partial failure: one symbol missing does not affect others
+- Snapshot is read-only after construction (mutating cache does not change it)
+- Cache is consulted exactly once per symbol (no duplicate provider calls)
+- from_cache() handles None cache gracefully
+"""
+
+import time
+import pytest
+
+from v3_pipeline.data.market_snapshot import MarketDataSnapshot
+
+
+# ── Minimal cache stub ────────────────────────────────────────────────────────
+
+
+class _MockCache:
+    def __init__(self, data: dict):
+        self._data = data
+        self.get_calls: list[str] = []
+
+    def get(self, symbol, default=None):
+        self.get_calls.append(symbol)
+        return self._data.get(symbol, default)
+
+
+def _fresh_quote(close: float = 100.0) -> dict:
+    return {
+        "Date": "2026-01-01",
+        "Open": close,
+        "High": close + 1,
+        "Low": close - 1,
+        "Close": close,
+        "Volume": 10000,
+        "data_source": "test",
+        "_cached_at": time.time(),
+    }
+
+
+# ── from_cache() populates correct dicts ─────────────────────────────────────
+
+
+def test_snapshot_includes_fresh_symbols():
+    cache = _MockCache({"TSLA": _fresh_quote(200.0), "NVDA": _fresh_quote(500.0)})
+    snap = MarketDataSnapshot.from_cache(cache, ["TSLA", "NVDA"])
+    assert "TSLA" in snap
+    assert "NVDA" in snap
+    assert snap.get("TSLA")["Close"] == pytest.approx(200.0)
+
+
+def test_snapshot_excludes_missing_symbols():
+    cache = _MockCache({"TSLA": _fresh_quote()})
+    snap = MarketDataSnapshot.from_cache(cache, ["TSLA", "NVDA"])
+    assert "TSLA" in snap
+    assert "NVDA" not in snap
+
+
+def test_snapshot_miss_reason_for_absent_symbol():
+    cache = _MockCache({})
+    snap = MarketDataSnapshot.from_cache(cache, ["TSLA"])
+    assert snap.miss_reason("TSLA") is not None
+    assert isinstance(snap.miss_reason("TSLA"), str)
+    assert len(snap.miss_reason("TSLA")) > 0
+
+
+def test_snapshot_no_miss_reason_for_present_symbol():
+    cache = _MockCache({"TSLA": _fresh_quote()})
+    snap = MarketDataSnapshot.from_cache(cache, ["TSLA"])
+    assert snap.miss_reason("TSLA") is None
+
+
+# ── Partial failure isolation ─────────────────────────────────────────────────
+
+
+def test_partial_failure_does_not_affect_other_symbols():
+    cache = _MockCache({
+        "TSLA": _fresh_quote(200.0),
+        "NVDA": None,              # miss
+        "AAPL": _fresh_quote(150.0),
+    })
+    snap = MarketDataSnapshot.from_cache(cache, ["TSLA", "NVDA", "AAPL"])
+    assert snap.get("TSLA")["Close"] == pytest.approx(200.0)
+    assert snap.get("NVDA") is None
+    assert snap.get("AAPL")["Close"] == pytest.approx(150.0)
+    assert snap.miss_reason("NVDA") is not None
+
+
+def test_missing_symbols_lists_only_misses():
+    cache = _MockCache({"TSLA": _fresh_quote()})
+    snap = MarketDataSnapshot.from_cache(cache, ["TSLA", "NVDA", "AAPL"])
+    missing = snap.missing_symbols()
+    assert "NVDA" in missing
+    assert "AAPL" in missing
+    assert "TSLA" not in missing
+
+
+def test_present_symbols_lists_only_hits():
+    cache = _MockCache({"TSLA": _fresh_quote(), "NVDA": _fresh_quote()})
+    snap = MarketDataSnapshot.from_cache(cache, ["TSLA", "NVDA", "AAPL"])
+    present = snap.present_symbols()
+    assert "TSLA" in present
+    assert "NVDA" in present
+    assert "AAPL" not in present
+
+
+# ── Cache consulted exactly once per symbol ───────────────────────────────────
+
+
+def test_cache_get_called_exactly_once_per_symbol():
+    cache = _MockCache({"TSLA": _fresh_quote(), "NVDA": _fresh_quote()})
+    MarketDataSnapshot.from_cache(cache, ["TSLA", "NVDA", "AAPL"])
+    assert cache.get_calls.count("TSLA") == 1
+    assert cache.get_calls.count("NVDA") == 1
+    assert cache.get_calls.count("AAPL") == 1
+
+
+# ── Snapshot immutability ─────────────────────────────────────────────────────
+
+
+def test_snapshot_not_affected_by_cache_mutation():
+    data = {"TSLA": _fresh_quote(200.0)}
+    cache = _MockCache(data)
+    snap = MarketDataSnapshot.from_cache(cache, ["TSLA"])
+    # Mutate the cache after snapshot is built
+    data["TSLA"] = _fresh_quote(999.0)
+    # Snapshot must still return original value
+    assert snap.get("TSLA")["Close"] == pytest.approx(200.0)
+
+
+def test_snapshot_len_counts_present_symbols():
+    cache = _MockCache({"TSLA": _fresh_quote(), "NVDA": _fresh_quote()})
+    snap = MarketDataSnapshot.from_cache(cache, ["TSLA", "NVDA", "AAPL"])
+    assert len(snap) == 2
+
+
+# ── None cache ────────────────────────────────────────────────────────────────
+
+
+def test_none_cache_treats_all_as_missing():
+    snap = MarketDataSnapshot.from_cache(None, ["TSLA", "NVDA"])
+    assert snap.get("TSLA") is None
+    assert snap.get("NVDA") is None
+    assert len(snap.missing_symbols()) == 2
+
+
+def test_empty_symbols_list_produces_empty_snapshot():
+    cache = _MockCache({"TSLA": _fresh_quote()})
+    snap = MarketDataSnapshot.from_cache(cache, [])
+    assert len(snap) == 0
+    assert snap.missing_symbols() == []
+
+
+# ── Quote with Close=0 treated as miss ───────────────────────────────────────
+
+
+def test_zero_close_treated_as_miss():
+    bad_quote = _fresh_quote(0.0)
+    cache = _MockCache({"TSLA": bad_quote})
+    snap = MarketDataSnapshot.from_cache(cache, ["TSLA"])
+    assert "TSLA" not in snap
+    assert snap.miss_reason("TSLA") is not None

--- a/v3_pipeline/data/market_snapshot.py
+++ b/v3_pipeline/data/market_snapshot.py
@@ -1,0 +1,96 @@
+"""Immutable quote snapshot for one trading cycle.
+
+At the start of each cycle, a MarketDataSnapshot is built once from the
+QuoteCache. Symbol cycles then read from the snapshot instead of hitting
+the provider directly, guaranteeing:
+
+- Each symbol is fetched at most once per cycle (no duplicate provider calls).
+- Partial failures are isolated per symbol — a miss for one symbol does not
+  skip others.
+- The snapshot is frozen: new provider responses during the cycle do not
+  change what the cycle sees.
+
+Usage::
+
+    snapshot = MarketDataSnapshot.from_cache(cache, symbols)
+    quote = snapshot.get("TSLA")    # returns dict or None
+    miss  = snapshot.miss_reason("TSLA")  # "stale_cache", "no_data", or None
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+_MISS_STALE_CACHE = "stale_cache"
+_MISS_NO_DATA = "no_data"
+
+
+class MarketDataSnapshot:
+    """Immutable snapshot of quotes for a set of symbols.
+
+    Built once at cycle start; read-only thereafter so the symbol-cycle
+    code never mutates shared cache state.
+    """
+
+    def __init__(
+        self,
+        quotes: dict[str, dict],
+        misses: dict[str, str],
+    ) -> None:
+        self._quotes = quotes
+        self._misses = misses
+
+    # ── Accessors ─────────────────────────────────────────────────────────────
+
+    def get(self, symbol: str, default: Any = None) -> Any:
+        """Return the quote dict for *symbol*, or *default* if absent / missed."""
+        return self._quotes.get(symbol, default)
+
+    def miss_reason(self, symbol: str) -> str | None:
+        """Return the miss reason string for *symbol*, or None if the quote is present."""
+        return self._misses.get(symbol)
+
+    def present_symbols(self) -> list[str]:
+        """Symbols for which quotes are available."""
+        return list(self._quotes)
+
+    def missing_symbols(self) -> list[str]:
+        """Symbols for which quotes are absent."""
+        return list(self._misses)
+
+    def __len__(self) -> int:
+        return len(self._quotes)
+
+    def __contains__(self, symbol: object) -> bool:
+        return symbol in self._quotes
+
+    # ── Factory ───────────────────────────────────────────────────────────────
+
+    @classmethod
+    def from_cache(
+        cls,
+        cache: Any,
+        symbols: list[str],
+    ) -> "MarketDataSnapshot":
+        """Build a snapshot by reading each symbol from *cache*.
+
+        Args:
+            cache: Any object with a ``get(symbol, default)`` method
+                   (QuoteCache-compatible).
+            symbols: The full list of symbols for this cycle.
+
+        Returns:
+            A MarketDataSnapshot with quotes for symbols that had a fresh
+            cache entry, and miss reasons for the rest.
+        """
+        quotes: dict[str, dict] = {}
+        misses: dict[str, str] = {}
+
+        for sym in symbols:
+            quote = cache.get(sym) if cache is not None else None
+            if quote is not None and isinstance(quote, dict) and quote.get("Close", 0) > 0:
+                quotes[sym] = quote
+            else:
+                misses[sym] = _MISS_NO_DATA if quote is None else _MISS_STALE_CACHE
+
+        return cls(quotes=quotes, misses=misses)


### PR DESCRIPTION
## Summary

- Quote access during symbol cycles was reading from the live `QuoteCache` — late provider responses could change mid-cycle quotes
- Add `v3_pipeline/data/market_snapshot.py`: `MarketDataSnapshot.from_cache(cache, symbols)` reads each symbol exactly once at cycle start, producing an immutable snapshot
- `.miss_reason(symbol)` returns a machine-readable reason string (`"no_data"` or `"stale_cache"`) for each absent symbol — partial failures are per-symbol and do not affect others
- `None` cache handled gracefully; zero-Close quotes treated as misses

## Test plan

- [x] `tests/test_market_data_snapshot.py` (new, 13 tests): present/absent symbol partitioning, partial failure isolation, cache consulted exactly once per symbol, snapshot immutability after cache mutation, `None` cache, empty symbol list, zero-Close as miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)