### PR TITLE
feat: async SQLite live-data persistence via LiveDbPersist (#84)

### DIFF
--- a/idle_task_scheduler.py
+++ b/idle_task_scheduler.py
@@ -156,6 +156,23 @@ def _emit_fd_health(logger: logging.Logger, mode: str = "check") -> None:
 
 # ── Task implementations ──────────────────────────────────────────────────────
 
+def _run_kline_refresh(symbols: list[str], logger: logging.Logger) -> tuple[int, int]:
+    """
+    Synchronous wrapper for KlineBackfill — intended to be called via asyncio.to_thread.
+    Returns (rows_repaired, rows_updated).
+    """
+    try:
+        from v3_pipeline.data.kline_backfill import KlineBackfill
+        kb = KlineBackfill()
+        repair = kb.run_smart_repair(symbols)
+        incremental = kb.run_incremental(symbols)
+        rows_repaired = sum(v for v in repair.values() if v > 0)
+        rows_updated = sum(v for v in incremental.values() if v > 0)
+        return rows_repaired, rows_updated
+    except Exception as exc:
+        logger.error("[db_refresh] KlineBackfill failed: %s", exc)
+        return 0, 0
+
 async def _run_historical_backfill(
     symbols: list[str],
     loop: "LiveTradingLoop",
@@ -435,6 +452,31 @@ class IdleTaskScheduler:
             if self._stop_event.is_set():
                 return
             _build_readiness_report(symbols, self.loop, self.logger)
+
+            # Task 4: DB K-line backfill + incremental update (kiro_quant.db)
+            if self._stop_event.is_set():
+                return
+            mins_left = self._minutes_until_next_open()
+            if mins_left <= self.cfg.stop_before_open_min:
+                self.logger.info(
+                    "[IdleTaskScheduler] Too close to open (%.0f min) — skipping DB refresh", mins_left
+                )
+            else:
+                t0 = time.time()
+                rows_repaired, rows_updated = await asyncio.to_thread(
+                    _run_kline_refresh, symbols, self.logger
+                )
+                self.logger.info(
+                    "[db_refresh] done in %.1fs — repaired=%d updated=%d",
+                    time.time() - t0, rows_repaired, rows_updated,
+                )
+                _emit(
+                    self.logger,
+                    "db_kline_refresh",
+                    rows_repaired=rows_repaired,
+                    rows_updated=rows_updated,
+                    duration_sec=round(time.time() - t0, 1),
+                )
 
         except asyncio.CancelledError:
             self.logger.info("[IdleTaskScheduler] cancelled")

--- a/idle_task_scheduler.py
+++ b/idle_task_scheduler.py
@@ -478,6 +478,27 @@ class IdleTaskScheduler:
                     duration_sec=round(time.time() - t0, 1),
                 )
 
+            # Task 5: DB archive — move old live rows to archive table (PR #83)
+            if self._stop_event.is_set():
+                return
+            try:
+                if hasattr(self.loop, 'db_persist') and self.loop.db_persist is not None:
+                    t0 = time.time()
+                    archived = await self.loop.db_persist.archive_old_data()
+                    self.logger.info(
+                        '[db_archive] done in %.1fs — archived=%d rows',
+                        time.time() - t0,
+                        archived,
+                    )
+                    _emit(
+                        self.logger,
+                        'db_archive',
+                        archived_rows=archived,
+                        duration_sec=round(time.time() - t0, 1),
+                    )
+            except Exception as exc:
+                self.logger.warning('[db_archive] failed: %s', exc)
+
         except asyncio.CancelledError:
             self.logger.info("[IdleTaskScheduler] cancelled")
             raise

--- a/tests/test_db_persist.py
+++ b/tests/test_db_persist.py
@@ -1,0 +1,239 @@
+"""Tests for v3_pipeline/data/db_persist.py (PR #83)"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from v3_pipeline.data.db_persist import LiveDbPersist, PersistConfig, _PendingRow
+
+
+# -- Helpers --
+
+
+def _make_df(n: int = 5, symbol: str = "AAPL") -> pd.DataFrame:
+    """Create a minimal market-buffer-style DataFrame."""
+    idx = pd.date_range("2026-05-16 09:30", periods=n, freq="min")
+    df = pd.DataFrame(
+        {
+            "Date": idx,
+            "Open": [100.0 + i for i in range(n)],
+            "High": [101.0 + i for i in range(n)],
+            "Low": [99.0 + i for i in range(n)],
+            "Close": [100.5 + i for i in range(n)],
+            "Volume": [1_000_000] * n,
+            "data_source": ["live"] * n,
+        }
+    )
+    return df
+
+
+def _run_with_sleep(coro_fn, sleep_sec: float = 0.3):
+    """Run an async coroutine, keep loop alive for sleep_sec so background tasks run, then return result."""
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        result = loop.run_until_complete(coro_fn)
+        if sleep_sec > 0:
+            # Run the event loop a bit more so background writer can flush
+            loop.run_until_complete(asyncio.sleep(sleep_sec))
+        return result
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
+# -- LiveDbPersist --
+
+
+@pytest.fixture
+def tmp_db():
+    with tempfile.TemporaryDirectory() as td:
+        yield Path(td) / "test_kiro.db"
+
+
+class TestInit:
+    def test_wal_enabled(self, tmp_db: Path):
+        p = LiveDbPersist(str(tmp_db))
+        conn = sqlite3.connect(str(tmp_db))
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        conn.close()
+        assert mode.upper() == "WAL"
+        asyncio.run(p.close())
+
+    def test_tables_created(self, tmp_db: Path):
+        p = LiveDbPersist(str(tmp_db))
+        conn = sqlite3.connect(str(tmp_db))
+        tables = [r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+        conn.close()
+        assert "market_data" in tables
+        assert "market_data_archive" in tables
+        asyncio.run(p.close())
+
+
+class TestEnqueueAndFlush:
+    def test_enqueue_writes_rows(self, tmp_db: Path):
+        cfg = PersistConfig(db_path=str(tmp_db), batch_size=2, flush_interval_sec=0.1)
+        p = LiveDbPersist(cfg=cfg)
+
+        async def _body():
+            await p.start()
+            df = _make_df(n=4, symbol="TSLA")
+            await p.enqueue("TSLA", df)
+            await asyncio.sleep(0.3)
+            await p.close()
+        asyncio.run(_body())
+
+        conn = sqlite3.connect(str(tmp_db))
+        rows = conn.execute("SELECT count(*) FROM market_data WHERE symbol='TSLA'").fetchone()[0]
+        conn.close()
+        assert rows == 4
+
+    def test_enqueue_multiple_symbols(self, tmp_db: Path):
+        cfg = PersistConfig(db_path=str(tmp_db), batch_size=5, flush_interval_sec=0.1)
+        p = LiveDbPersist(cfg=cfg)
+
+        async def _body():
+            await p.start()
+            for sym in ["AAPL", "MSFT", "NVDA"]:
+                await p.enqueue(sym, _make_df(n=3, symbol=sym))
+            await asyncio.sleep(0.3)
+            await p.close()
+        asyncio.run(_body())
+
+        conn = sqlite3.connect(str(tmp_db))
+        counts = {r[0]: r[1] for r in conn.execute("SELECT symbol, count(*) FROM market_data GROUP BY symbol")}
+        conn.close()
+        assert counts == {"AAPL": 3, "MSFT": 3, "NVDA": 3}
+
+    def test_upsert_replaces_duplicate_key(self, tmp_db: Path):
+        cfg = PersistConfig(db_path=str(tmp_db), batch_size=2, flush_interval_sec=0.1)
+        p = LiveDbPersist(cfg=cfg)
+
+        async def _body():
+            await p.start()
+            df1 = _make_df(n=2, symbol="AAPL")
+            await p.enqueue("AAPL", df1)
+            await asyncio.sleep(0.2)
+            df2 = df1.copy()
+            df2["Close"] = df2["Close"] + 10.0
+            await p.enqueue("AAPL", df2)
+            await asyncio.sleep(0.2)
+            await p.close()
+        asyncio.run(_body())
+
+        conn = sqlite3.connect(str(tmp_db))
+        rows = list(conn.execute("SELECT timestamp, close FROM market_data WHERE symbol='AAPL' ORDER BY timestamp"))
+        conn.close()
+        assert len(rows) == 2
+        assert rows[0][1] == pytest.approx(100.5 + 10.0)
+
+    def test_empty_df_noop(self, tmp_db: Path):
+        cfg = PersistConfig(db_path=str(tmp_db), batch_size=2, flush_interval_sec=0.1)
+        p = LiveDbPersist(cfg=cfg)
+
+        async def _body():
+            await p.start()
+            await p.enqueue("AAPL", pd.DataFrame())
+            await asyncio.sleep(0.2)
+            await p.close()
+        asyncio.run(_body())
+
+        assert p.stats()["enqueued"] == 0
+
+
+class TestQueueLimits:
+    def test_drops_when_queue_full(self, tmp_db: Path):
+        cfg = PersistConfig(db_path=str(tmp_db), batch_size=100, flush_interval_sec=60.0, max_queue_size=5)
+        p = LiveDbPersist(cfg=cfg)
+
+        async def _body():
+            await p.start()
+            df = _make_df(n=10, symbol="AAPL")
+            await p.enqueue("AAPL", df)
+            await asyncio.sleep(0.05)
+            await p.close()
+        asyncio.run(_body())
+
+        stats = p.stats()
+        assert stats["enqueued"] == 5
+        assert stats["dropped"] == 5
+
+
+class TestArchive:
+    def test_archive_moves_old_rows(self, tmp_db: Path):
+        cfg = PersistConfig(db_path=str(tmp_db), batch_size=10, flush_interval_sec=0.1, archive_after_days=0)
+        p = LiveDbPersist(cfg=cfg)
+
+        archived_result = []
+
+        async def _body():
+            await p.start()
+            df = _make_df(n=5, symbol="AAPL")
+            df["Date"] = pd.date_range("2026-05-15 09:30", periods=5, freq="min")
+            await p.enqueue("AAPL", df)
+            await asyncio.sleep(0.3)
+            # Archive while connection is still open, before close()
+            archived_result.append(await p.archive_old_data())
+            await p.close()
+        asyncio.run(_body())
+
+        conn = sqlite3.connect(str(tmp_db))
+        live_rows = conn.execute("SELECT count(*) FROM market_data WHERE symbol='AAPL'").fetchone()[0]
+        archive_rows = conn.execute("SELECT count(*) FROM market_data_archive WHERE symbol='AAPL'").fetchone()[0]
+        conn.close()
+
+        assert archived_result[0] == 5
+        assert live_rows == 0
+        assert archive_rows == 5
+
+
+class TestStats:
+    def test_stats_reflect_progress(self, tmp_db: Path):
+        cfg = PersistConfig(db_path=str(tmp_db), batch_size=2, flush_interval_sec=0.1)
+        p = LiveDbPersist(cfg=cfg)
+
+        async def _body():
+            await p.start()
+            await p.enqueue("AAPL", _make_df(n=4))
+            await asyncio.sleep(0.3)
+            await p.close()
+        asyncio.run(_body())
+
+        stats = p.stats()
+        assert stats["enqueued"] == 4
+        assert stats["written"] == 4
+        assert stats["queue_size"] == 0
+
+
+# -- Graceful shutdown --
+
+
+class TestClose:
+    def test_flush_on_close(self, tmp_db: Path):
+        cfg = PersistConfig(db_path=str(tmp_db), batch_size=100, flush_interval_sec=60.0)
+        p = LiveDbPersist(cfg=cfg)
+
+        async def _body():
+            await p.start()
+            await p.enqueue("AAPL", _make_df(n=3))
+            # Immediately close -- should flush pending rows
+            await p.close()
+        asyncio.run(_body())
+
+        conn = sqlite3.connect(str(tmp_db))
+        rows = conn.execute("SELECT count(*) FROM market_data").fetchone()[0]
+        conn.close()
+        assert rows == 3
+
+    def test_idempotent_close(self, tmp_db: Path):
+        p = LiveDbPersist(str(tmp_db))
+        asyncio.run(p.start())
+        asyncio.run(p.close())
+        # Second close should be harmless
+        asyncio.run(p.close())

--- a/tests/test_kline_backfill.py
+++ b/tests/test_kline_backfill.py
@@ -1,0 +1,223 @@
+"""Tests for v3_pipeline/data/kline_backfill.py"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from v3_pipeline.data.kline_backfill import (
+    MIN_BARS,
+    KlineBackfill,
+    _prepare_ohlcv,
+    _to_db_frame,
+    _to_utc_naive_str,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_hist(n: int = 80, tz_aware: bool = True) -> pd.DataFrame:
+    """Create a minimal ticker.history()-style DataFrame."""
+    import numpy as np
+
+    idx = pd.date_range("2024-01-01", periods=n, freq="B")
+    if tz_aware:
+        idx = idx.tz_localize("America/New_York")
+    df = pd.DataFrame(
+        {
+            "Open": np.linspace(100, 110, n),
+            "High": np.linspace(101, 111, n),
+            "Low": np.linspace(99, 109, n),
+            "Close": np.linspace(100.5, 110.5, n),
+            "Volume": [1_000_000] * n,
+            "Dividends": [0.0] * n,
+            "Stock Splits": [0.0] * n,
+        },
+        index=idx,
+    )
+    df.index.name = "Date"
+    return df
+
+
+def _make_db(path: str, symbol: str = "AAPL", bars: int = 0) -> None:
+    """Bootstrap a minimal kiro_quant.db at path with optional pre-filled rows."""
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS market_data (
+            symbol TEXT, timestamp DATETIME,
+            open REAL, high REAL, low REAL, close REAL, volume REAL,
+            data_source TEXT,
+            PRIMARY KEY (symbol, timestamp))"""
+    )
+    if bars:
+        rows = [(symbol, f"2024-01-{i+1:02d} 00:00:00", 100.0, 101.0, 99.0, 100.5, 1e6, "YF_HIST")
+                for i in range(bars)]
+        conn.executemany(
+            "INSERT OR REPLACE INTO market_data VALUES (?,?,?,?,?,?,?,?)", rows
+        )
+    conn.commit()
+    conn.close()
+
+
+# ── _to_utc_naive_str ─────────────────────────────────────────────────────────
+
+class TestToUtcNaiveStr:
+    def test_aware_pd_timestamp(self):
+        ts = pd.Timestamp("2026-03-17 15:59:00", tz="America/New_York")
+        result = _to_utc_naive_str(ts)
+        # UTC would be 19:59:00
+        assert "+" not in result and "Z" not in result
+        assert result.startswith("2026-03-17")
+
+    def test_naive_pd_timestamp(self):
+        ts = pd.Timestamp("2026-03-17 09:30:00")
+        assert _to_utc_naive_str(ts) == "2026-03-17 09:30:00"
+
+    def test_aware_datetime(self):
+        ts = datetime(2026, 3, 17, 15, 59, 0, tzinfo=timezone.utc)
+        result = _to_utc_naive_str(ts)
+        assert result == "2026-03-17 15:59:00"
+
+    def test_string_with_offset(self):
+        result = _to_utc_naive_str("2026-03-17 15:59:00-04:00")
+        assert "+" not in result and result.count("-") <= 2
+        assert result.startswith("2026-03-17 15:59:00")
+
+    def test_string_no_offset(self):
+        assert _to_utc_naive_str("2026-03-16 00:00:00") == "2026-03-16 00:00:00"
+
+
+# ── _prepare_ohlcv ────────────────────────────────────────────────────────────
+
+class TestPrepareOhlcv:
+    def test_returns_required_columns(self):
+        hist = _make_hist(20)
+        df = _prepare_ohlcv(hist)
+        for col in ("Date", "Open", "High", "Low", "Close", "Volume"):
+            assert col in df.columns, f"missing {col}"
+
+    def test_strips_extra_columns(self):
+        hist = _make_hist(20)
+        df = _prepare_ohlcv(hist)
+        assert "Dividends" not in df.columns
+        assert "Stock Splits" not in df.columns
+
+    def test_timezone_stripped(self):
+        hist = _make_hist(20, tz_aware=True)
+        df = _prepare_ohlcv(hist)
+        for val in df["Date"]:
+            assert "+" not in str(val) and "-0" not in str(val)[-6:]
+
+    def test_empty_input_returns_empty(self):
+        result = _prepare_ohlcv(pd.DataFrame())
+        assert result.empty
+
+
+# ── _to_db_frame ──────────────────────────────────────────────────────────────
+
+class TestToDbFrame:
+    def test_renames_and_adds_metadata(self):
+        hist = _make_hist(10)
+        ohlcv = _prepare_ohlcv(hist)
+        db_frame = _to_db_frame(ohlcv, "TSLA", "YF_HIST")
+        assert "timestamp" in db_frame.columns
+        assert db_frame["symbol"].iloc[0] == "TSLA"
+        assert db_frame["data_source"].iloc[0] == "YF_HIST"
+        assert "Date" not in db_frame.columns
+
+    def test_data_source_live(self):
+        hist = _make_hist(5)
+        ohlcv = _prepare_ohlcv(hist)
+        db_frame = _to_db_frame(ohlcv, "AAPL", "YF_LIVE")
+        assert (db_frame["data_source"] == "YF_LIVE").all()
+
+
+# ── KlineBackfill ─────────────────────────────────────────────────────────────
+
+class TestKlineBackfill:
+    def _make_kb(self, tmp_path: Path, prefill_sym: str = "", bars: int = 0) -> KlineBackfill:
+        db_file = str(tmp_path / "test.db")
+        _make_db(db_file, prefill_sym, bars)
+        kb = KlineBackfill(db_path=db_file, cooldown_sec=0.0)
+        return kb
+
+    def test_symbols_needing_backfill_empty_db(self, tmp_path):
+        kb = self._make_kb(tmp_path)
+        result = kb.symbols_needing_backfill(["AAPL", "MSFT"])
+        assert set(result) == {"AAPL", "MSFT"}
+
+    def test_symbols_needing_backfill_sufficient(self, tmp_path):
+        kb = self._make_kb(tmp_path, "AAPL", MIN_BARS)
+        result = kb.symbols_needing_backfill(["AAPL"])
+        assert result == []
+
+    def test_symbols_needing_backfill_insufficient(self, tmp_path):
+        kb = self._make_kb(tmp_path, "AAPL", MIN_BARS - 1)
+        result = kb.symbols_needing_backfill(["AAPL"])
+        assert result == ["AAPL"]
+
+    @patch("v3_pipeline.data.kline_backfill.KlineBackfill._fetch_and_save")
+    def test_run_smart_repair_skips_if_sufficient(self, mock_fetch, tmp_path):
+        kb = self._make_kb(tmp_path, "AAPL", MIN_BARS)
+        result = kb.run_smart_repair(["AAPL"])
+        mock_fetch.assert_not_called()
+        assert result == {}
+
+    @patch("v3_pipeline.data.kline_backfill.KlineBackfill._fetch_and_save", return_value={"MSFT": 500})
+    def test_run_smart_repair_calls_fetch_for_missing(self, mock_fetch, tmp_path):
+        kb = self._make_kb(tmp_path)
+        result = kb.run_smart_repair(["MSFT"])
+        mock_fetch.assert_called_once()
+        _, call_kwargs = mock_fetch.call_args
+        # period should be FULL_PERIOD, data_source YF_HIST
+        args = mock_fetch.call_args[0]
+        assert args[1] == "2y"
+        assert args[2] == "YF_HIST"
+
+    @patch("v3_pipeline.data.kline_backfill.KlineBackfill._fetch_and_save", return_value={"AAPL": 5})
+    def test_run_incremental_always_fetches(self, mock_fetch, tmp_path):
+        kb = self._make_kb(tmp_path, "AAPL", MIN_BARS)
+        result = kb.run_incremental(["AAPL"])
+        mock_fetch.assert_called_once()
+        args = mock_fetch.call_args[0]
+        assert args[1] == "5d"
+        assert args[2] == "YF_LIVE"
+
+    def test_integration_saves_to_db(self, tmp_path):
+        """End-to-end: mock yf_provider, verify rows land in DB with correct data_source."""
+        db_file = str(tmp_path / "test.db")
+        _make_db(db_file)
+
+        hist = _make_hist(80)
+
+        with patch("v3_pipeline.data.yf_provider.download_history", return_value={"NVDA": hist}):
+            kb = KlineBackfill(db_path=db_file, cooldown_sec=0.0)
+            saved = kb.run_smart_repair(["NVDA"])
+
+        assert saved.get("NVDA", 0) > 0
+
+        conn = sqlite3.connect(db_file)
+        rows = conn.execute(
+            "SELECT COUNT(*), data_source FROM market_data WHERE symbol='NVDA' GROUP BY data_source"
+        ).fetchall()
+        conn.close()
+        assert rows, "no rows saved for NVDA"
+        count, source = rows[0]
+        assert count > 0
+        assert source == "YF_HIST"
+
+    def test_run_full_cycle_returns_both_dicts(self, tmp_path):
+        kb = self._make_kb(tmp_path)
+        with patch.object(kb, "run_smart_repair", return_value={"A": 500}) as m1, \
+             patch.object(kb, "run_incremental", return_value={"A": 5}) as m2:
+            repair, incremental = kb.run_full_cycle(["A"])
+        m1.assert_called_once_with(["A"])
+        m2.assert_called_once_with(["A"])
+        assert repair == {"A": 500}
+        assert incremental == {"A": 5}

--- a/v3_pipeline/core/main_loop.py
+++ b/v3_pipeline/core/main_loop.py
@@ -22,6 +22,7 @@ from v3_pipeline.features.indicators import TechnicalIndicatorGenerator
 from v3_pipeline.models.manager import DataPreparer, ModelManager
 from v3_pipeline.risk.kelly_sizer import KellyPositionSizer
 from v3_pipeline.risk.manager import RiskController
+from v3_pipeline.data.db_persist import LiveDbPersist
 
 
 def _get_log_dir() -> Path:
@@ -294,11 +295,17 @@ class LiveTradingLoop:
             for s in self.symbols
         }
 
+        # -- DB persistence (PR #83) --
+        self.db_persist = LiveDbPersist(db_path="kiro_quant.db")
+
     def start(self) -> None:
         self.futu_connector.connect()
+        asyncio.run(self.db_persist.start())
         try:
             asyncio.run(self._run_forever())
         finally:
+            asyncio.run(self.db_persist.flush())
+            asyncio.run(self.db_persist.close())
             self._archive_market_data()
             self.futu_connector.close()
 
@@ -387,6 +394,14 @@ class LiveTradingLoop:
                 await self._run_symbol_cycle(symbol)
 
         await asyncio.gather(*(guarded(symbol) for symbol in self.symbols))
+
+        # -- Persist market buffers to DB (PR #83) --
+        try:
+            for sym, df in self.market_buffers.items():
+                if not df.empty:
+                    await self.db_persist.enqueue(sym, df)
+        except Exception as exc:
+            self.logger.warning('[DB_PERSIST] enqueue failed: %s', exc)
 
     async def _prefetch_quotes(self) -> None:
         """

--- a/v3_pipeline/data/db_persist.py
+++ b/v3_pipeline/data/db_persist.py
@@ -1,0 +1,349 @@
+"""
+db_persist.py — High-frequency SQLite persistence for live trading market data.
+
+Improvements over db_manager.py:
+  • Persistent connection (no open/close per write)
+  • WAL mode for better read/write concurrency
+  • Async queue + background worker to avoid blocking the main loop
+  • Batch UPSERT (INSERT OR REPLACE) with configurable batch size & flush interval
+  • Graceful shutdown with pending flush
+
+Usage in LiveTradingLoop:
+    from v3_pipeline.data.db_persist import LiveDbPersist
+    self.db_persist = LiveDbPersist("kiro_quant.db")
+    # At end of each cycle:
+    await self.db_persist.enqueue(symbol, buffer_df)
+    # On shutdown:
+    await self.db_persist.close()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+logger = logging.getLogger("kiro.db_persist")
+
+# Sentinel for background worker shutdown
+_POISON = object()
+
+
+@dataclass
+class PersistConfig:
+    db_path: str = "kiro_quant.db"
+    batch_size: int = 500          # Max rows per SQLite executemany batch
+    max_queue_size: int = 20000  # Rows; oldest dropped if exceeded to protect memory
+    flush_interval_sec: float = 5.0   # Force flush every N seconds
+    wal_checkpoint_pages: int = 1000  # PRAGMA wal_autocheckpoint
+    archive_after_days: int = 30      # Move rows older than N days to archive table
+
+
+@dataclass
+class _PendingRow:
+    symbol: str
+    timestamp: str
+    open_: float
+    high: float
+    low: float
+    close: float
+    volume: float
+    data_source: str = "live"
+
+
+class LiveDbPersist:
+    """
+    Async SQLite persistence layer optimised for high-frequency live trading.
+
+    Features
+    --------
+    • Background writer coroutine drains an asyncio.Queue and commits in batches.
+    • Persistent sqlite3.Connection with WAL + synchronous=NORMAL for throughput.
+    • Automatic schema migration (adds missing columns dynamically).
+    • Optional idle-time archive that moves old rows to ``market_data_archive``.
+    """
+
+    def __init__(self, db_path: Optional[str] = None, cfg: Optional[PersistConfig] = None):
+        self.cfg = cfg or PersistConfig()
+        if db_path:
+            self.cfg.db_path = db_path
+        self._conn: Optional[sqlite3.Connection] = None
+        self._queue: asyncio.Queue[_PendingRow | None] = asyncio.Queue()
+        self._worker_task: Optional[asyncio.Task] = None
+        self._closed = False
+        self._flush_event = asyncio.Event()
+        self._total_enqueued = 0
+        self._total_written = 0
+        self._dropped = 0
+        self._ensure_db()
+
+    # ── Public API ──────────────────────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Launch the background writer coroutine."""
+        if self._worker_task is None or self._worker_task.done():
+            self._worker_task = asyncio.create_task(self._writer_loop())
+            logger.info("[db_persist] writer started (db=%s)", self.cfg.db_path)
+
+    async def enqueue(self, symbol: str, df: pd.DataFrame) -> None:
+        """Queue a DataFrame of market bars for asynchronous persistence."""
+        if self._closed or df.empty:
+            return
+        # Drop oldest rows if queue is over limit to avoid unbounded memory growth
+        qsize = self._queue.qsize()
+        rows_to_add = len(df)
+        if qsize + rows_to_add > self.cfg.max_queue_size:
+            excess = qsize + rows_to_add - self.cfg.max_queue_size
+            self._dropped += excess
+            logger.warning(
+                "[db_persist] queue limit exceeded — dropping %d rows (symbol=%s)",
+                excess,
+                symbol,
+            )
+            if excess >= rows_to_add:
+                return
+            df = df.iloc[-(rows_to_add - excess) :].copy()
+
+        for _, row in df.iterrows():
+            ts = row.get("Date", row.get("timestamp", pd.Timestamp.now(tz="UTC")))
+            if isinstance(ts, pd.Timestamp):
+                ts = ts.strftime("%Y-%m-%d %H:%M:%S")
+            pending = _PendingRow(
+                symbol=symbol,
+                timestamp=ts,
+                open_=float(row.get("Open", 0.0) or 0.0),
+                high=float(row.get("High", 0.0) or 0.0),
+                low=float(row.get("Low", 0.0) or 0.0),
+                close=float(row.get("Close", 0.0) or 0.0),
+                volume=float(row.get("Volume", 0.0) or 0.0),
+                data_source=str(row.get("data_source", "live")),
+            )
+            await self._queue.put(pending)
+            self._total_enqueued += 1
+
+    async def flush(self) -> None:
+        """Signal the writer to flush immediately and wait until drained."""
+        if self._worker_task is None or self._worker_task.done():
+            return
+        self._flush_event.set()
+        for _ in range(100):
+            if self._queue.empty():
+                break
+            await asyncio.sleep(0.05)
+
+    async def archive_old_data(self) -> int:
+        """
+        Move rows older than ``archive_after_days`` to ``market_data_archive``.
+        Returns number of rows archived.
+        """
+        return await asyncio.to_thread(self._archive_old_data_sync)
+
+    async def close(self) -> None:
+        """Graceful shutdown: flush queue, stop worker, close connection."""
+        if self._closed:
+            return
+        self._closed = True
+        await self._queue.put(_POISON)  # Poison pill
+        if self._worker_task and not self._worker_task.done():
+            try:
+                await asyncio.wait_for(self._worker_task, timeout=10.0)
+            except asyncio.TimeoutError:
+                self._worker_task.cancel()
+                try:
+                    await self._worker_task
+                except asyncio.CancelledError:
+                    pass
+        await asyncio.to_thread(self._close_conn)
+        logger.info(
+            "[db_persist] closed — enqueued=%d written=%d dropped=%d",
+            self._total_enqueued,
+            self._total_written,
+            self._dropped,
+        )
+
+    # ── Sync helpers (run via asyncio.to_thread) ───────────────────────────────
+
+    def _ensure_db(self) -> None:
+        """Initialise DB, enable WAL, create tables if missing."""
+        self._conn = sqlite3.connect(self.cfg.db_path, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode = WAL")
+        self._conn.execute("PRAGMA synchronous = NORMAL")
+        self._conn.execute(f"PRAGMA wal_autocheckpoint = {self.cfg.wal_checkpoint_pages}")
+        self._conn.execute("PRAGMA temp_store = MEMORY")
+        self._conn.execute("PRAGMA mmap_size = 30000000000")
+        self._conn.commit()
+
+        # Main live table
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS market_data (
+                symbol TEXT,
+                timestamp DATETIME,
+                open REAL,
+                high REAL,
+                low REAL,
+                close REAL,
+                volume REAL,
+                data_source TEXT,
+                PRIMARY KEY (symbol, timestamp)
+            ) WITHOUT ROWID
+            """
+        )
+        # Archive table (identical schema, no PK constraint for speed)
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS market_data_archive (
+                symbol TEXT,
+                timestamp DATETIME,
+                open REAL,
+                high REAL,
+                low REAL,
+                close REAL,
+                volume REAL,
+                data_source TEXT
+            )
+            """
+        )
+        # Index for archive queries
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_archive_symbol_ts ON market_data_archive(symbol, timestamp)"
+        )
+        self._conn.commit()
+        logger.info("[db_persist] DB initialised (WAL) at %s", self.cfg.db_path)
+
+    def _close_conn(self) -> None:
+        if self._conn:
+            try:
+                self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                self._conn.commit()
+            except Exception:
+                pass
+            self._conn.close()
+            self._conn = None
+
+    def _batch_upsert(self, rows: list[_PendingRow]) -> int:
+        """Synchronous batch write inside the background worker."""
+        if not rows or self._conn is None:
+            return 0
+        sql = """
+            INSERT OR REPLACE INTO market_data
+            (symbol, timestamp, open, high, low, close, volume, data_source)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """
+        params = [
+            (r.symbol, r.timestamp, r.open_, r.high, r.low, r.close, r.volume, r.data_source)
+            for r in rows
+        ]
+        try:
+            self._conn.executemany(sql, params)
+            self._conn.commit()
+            return len(rows)
+        except sqlite3.OperationalError as exc:
+            logger.error("[db_persist] batch upsert failed: %s", exc)
+            return 0
+
+    def _archive_old_data_sync(self) -> int:
+        """
+        Synchronous archive implementation.
+
+        Opens its own connection so it doesn't contend with the background
+        writer thread, which holds self._conn for batch writes.
+        WAL mode allows the two connections to serialise cleanly.
+        """
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=self.cfg.archive_after_days)).strftime("%Y-%m-%d %H:%M:%S")
+        try:
+            conn = sqlite3.connect(self.cfg.db_path, timeout=30)
+            conn.execute("PRAGMA journal_mode = WAL")
+            try:
+                cur = conn.execute(
+                    "INSERT INTO market_data_archive SELECT * FROM market_data WHERE timestamp < ?",
+                    (cutoff,),
+                )
+                archived = cur.rowcount
+                if archived:
+                    conn.execute("DELETE FROM market_data WHERE timestamp < ?", (cutoff,))
+                    conn.commit()
+                    logger.info("[db_persist] archived %d rows older than %s", archived, cutoff)
+                return archived
+            finally:
+                conn.close()
+        except sqlite3.OperationalError as exc:
+            logger.error("[db_persist] archive failed: %s", exc)
+            return 0
+
+    # ── Background writer ───────────────────────────────────────────────────────
+
+    async def _writer_loop(self) -> None:
+        """Coroutine that drains the queue and commits in batches."""
+        batch: list[_PendingRow] = []
+        last_flush = asyncio.get_event_loop().time()
+
+        while True:
+            try:
+                # Wait for a row, but time out at flush_interval_sec
+                elapsed = asyncio.get_event_loop().time() - last_flush
+                timeout = self.cfg.flush_interval_sec - elapsed
+                if timeout > 0.001:
+                    item = await asyncio.wait_for(self._queue.get(), timeout=timeout)
+                else:
+                    item = await self._queue.get()
+            except asyncio.TimeoutError:
+                item = None  # Force a flush check
+
+            if item is None:
+                # Timeout flush
+                if batch:
+                    written = await asyncio.to_thread(self._batch_upsert, batch)
+                    self._total_written += written
+                    batch.clear()
+                    last_flush = asyncio.get_event_loop().time()
+                if self._closed:
+                    break
+                continue
+
+            if item is _POISON:
+                if batch:
+                    written = await asyncio.to_thread(self._batch_upsert, batch)
+                    self._total_written += written
+                    batch.clear()
+                    last_flush = asyncio.get_event_loop().time()
+                break
+
+            batch.append(item)
+
+            if len(batch) >= self.cfg.batch_size:
+                written = await asyncio.to_thread(self._batch_upsert, batch)
+                self._total_written += written
+                batch.clear()
+                last_flush = asyncio.get_event_loop().time()
+
+            # Also handle explicit flush requests
+            if self._flush_event.is_set():
+                if batch:
+                    written = await asyncio.to_thread(self._batch_upsert, batch)
+                    self._total_written += written
+                    batch.clear()
+                    last_flush = asyncio.get_event_loop().time()
+                self._flush_event.clear()
+
+        # Final drain (should already be empty, but be safe)
+        if batch:
+            written = await asyncio.to_thread(self._batch_upsert, batch)
+            self._total_written += written
+
+    # ── Health / introspection ────────────────────────────────────────────────
+
+    def stats(self) -> dict:
+        return {
+            "enqueued": self._total_enqueued,
+            "written": self._total_written,
+            "dropped": self._dropped,
+            "queue_size": self._queue.qsize(),
+            "db_path": self.cfg.db_path,
+        }

--- a/v3_pipeline/data/kline_backfill.py
+++ b/v3_pipeline/data/kline_backfill.py
@@ -1,0 +1,225 @@
+"""
+KlineBackfill — historical K-line data backfill and maintenance for kiro_quant.db.
+
+Responsibilities:
+  - Initial full backfill for symbols missing ≥MIN_BARS daily bars
+  - Incremental daily updates (last 5d) for all watchlist symbols
+  - Proper data_source tagging: "YF_HIST" (backfill) / "YF_LIVE" (incremental)
+  - Timezone-normalised timestamps (UTC naive, no offset suffix)
+
+Integration point: called from IdleTaskScheduler Task 4 via asyncio.to_thread.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+logger = logging.getLogger("kiro.kline_backfill")
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+_DB_PATH = _REPO_ROOT / "kiro_quant.db"
+
+MIN_BARS = 60
+FULL_PERIOD = "2y"
+INCREMENTAL_PERIOD = "5d"
+_DEFAULT_BATCH_SIZE = 10
+_DEFAULT_COOLDOWN_SEC = 2.0
+
+
+# ── Timestamp normalisation ───────────────────────────────────────────────────
+
+def _to_utc_naive_str(ts: object) -> str:
+    """Convert any timestamp (pd.Timestamp, datetime, str) to a UTC-naive ISO string."""
+    if isinstance(ts, (pd.Timestamp, datetime)):
+        if getattr(ts, "tzinfo", None) is not None:
+            ts = ts.astimezone(timezone.utc).replace(tzinfo=None)  # type: ignore[union-attr]
+        return ts.strftime("%Y-%m-%d %H:%M:%S")
+    # Raw string from DB (e.g. "2026-03-17 15:59:00-04:00") — strip offset
+    raw = str(ts).split(".")[0]  # drop microseconds
+    for sep in ("+", "-0", "-1"):             # crude offset strip
+        if sep in raw[10:]:                   # only look past the date portion
+            raw = raw[: raw.rfind(sep, 10)]
+    return raw.strip()
+
+
+# ── DataFrame preparation ─────────────────────────────────────────────────────
+
+def _prepare_ohlcv(hist: pd.DataFrame) -> pd.DataFrame:
+    """
+    Normalise a raw ticker.history() DataFrame for TechnicalIndicatorGenerator.
+
+    Output has the exact columns generate() needs:
+      Date, Open, High, Low, Close, Volume  (capital letters, Date is string UTC-naive)
+    """
+    if hist.empty:
+        return pd.DataFrame()
+
+    df = hist.reset_index()
+
+    # ticker.history(interval="1d") → index named "Date"; intraday → "Datetime"
+    for col in ("Datetime", "Date"):
+        if col in df.columns:
+            df = df.rename(columns={col: "Date"})
+            break
+
+    # Keep only what generate() and the DB need; drop Dividends / Stock Splits
+    keep = ["Date", "Open", "High", "Low", "Close", "Volume"]
+    df = df[[c for c in keep if c in df.columns]].copy()
+
+    if "Date" not in df.columns:
+        logger.warning("[kline_backfill] no Date column after reset_index, skipping frame")
+        return pd.DataFrame()
+
+    df["Date"] = df["Date"].apply(_to_utc_naive_str)
+    df = df.dropna(subset=["Open", "High", "Low", "Close"])
+    return df
+
+
+def _to_db_frame(featured: pd.DataFrame, symbol: str, data_source: str) -> pd.DataFrame:
+    """Rename Date→timestamp, add symbol/data_source, ready for DatabaseManager.save_data()."""
+    df = featured.rename(columns={
+        "Date": "timestamp",
+        "Open": "open",
+        "High": "high",
+        "Low": "low",
+        "Close": "close",
+        "Volume": "volume",
+    }).copy()
+    df["symbol"] = symbol
+    df["data_source"] = data_source
+    return df
+
+
+# ── Main class ────────────────────────────────────────────────────────────────
+
+class KlineBackfill:
+    """
+    Fetch, compute TA, and persist daily K-line data to kiro_quant.db.
+
+    Typical usage inside IdleTaskScheduler (Task 4):
+        kb = KlineBackfill()
+        repair_counts  = kb.run_smart_repair(IDLE_COLLECTION_SYMBOLS)
+        update_counts  = kb.run_incremental(IDLE_COLLECTION_SYMBOLS)
+    """
+
+    def __init__(
+        self,
+        db_path: str | None = None,
+        batch_size: int = _DEFAULT_BATCH_SIZE,
+        cooldown_sec: float = _DEFAULT_COOLDOWN_SEC,
+    ) -> None:
+        # Ensure repo root is importable regardless of cwd
+        repo = str(_REPO_ROOT)
+        if repo not in sys.path:
+            sys.path.insert(0, repo)
+
+        from db_manager import DatabaseManager
+        from v3_pipeline.features.indicators import TechnicalIndicatorGenerator
+
+        self._db = DatabaseManager(db_path or str(_DB_PATH))
+        self._indicator_gen = TechnicalIndicatorGenerator()
+        self._batch_size = batch_size
+        self._cooldown_sec = cooldown_sec
+
+    # ── Health check ──────────────────────────────────────────────────────────
+
+    def symbol_health(self, symbols: list[str]) -> dict[str, dict]:
+        return self._db.check_health(symbols)
+
+    def symbols_needing_backfill(self, symbols: list[str]) -> list[str]:
+        health = self.symbol_health(symbols)
+        return [s for s in symbols if (health.get(s) or {}).get("count", 0) < MIN_BARS]
+
+    # ── Core fetch + save ─────────────────────────────────────────────────────
+
+    def _fetch_and_save(
+        self,
+        symbols: list[str],
+        period: str,
+        data_source: str,
+    ) -> dict[str, int]:
+        """
+        For each batch: download → compute TA → save.
+        Returns {symbol: rows_saved}.
+        """
+        from v3_pipeline.data.yf_provider import download_history
+
+        saved: dict[str, int] = {}
+        n_batches = (len(symbols) + self._batch_size - 1) // self._batch_size
+
+        for i in range(0, len(symbols), self._batch_size):
+            batch = symbols[i : i + self._batch_size]
+            batch_no = i // self._batch_size + 1
+            t0 = time.time()
+
+            hist_map = download_history(batch, period=period, interval="1d")
+
+            for sym, hist in hist_map.items():
+                if hist.empty:
+                    logger.warning("[kline_backfill][%s] empty history — skipping", sym)
+                    saved[sym] = 0
+                    continue
+                try:
+                    ohlcv = _prepare_ohlcv(hist)
+                    if ohlcv.empty:
+                        saved[sym] = 0
+                        continue
+
+                    featured = self._indicator_gen.generate(ohlcv)
+                    db_frame = _to_db_frame(featured, sym, data_source)
+
+                    self._db.save_data(db_frame, symbol=sym)
+                    saved[sym] = len(db_frame)
+                    logger.info(
+                        "[kline_backfill][%s] %d rows → DB (%s)",
+                        sym, len(db_frame), data_source,
+                    )
+                except Exception as exc:
+                    logger.warning("[kline_backfill][%s] failed: %s", sym, exc)
+                    saved[sym] = 0
+
+            logger.info(
+                "[kline_backfill] batch %d/%d done in %.1fs",
+                batch_no, n_batches, time.time() - t0,
+            )
+            if i + self._batch_size < len(symbols):
+                time.sleep(self._cooldown_sec)
+
+        return saved
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def run_smart_repair(self, symbols: list[str]) -> dict[str, int]:
+        """
+        Full 2-year backfill for symbols with <60 bars.
+        Skips symbols that already have enough data.
+        """
+        needs = self.symbols_needing_backfill(symbols)
+        if not needs:
+            logger.info(
+                "[kline_backfill] all %d symbols have ≥%d bars — repair skipped",
+                len(symbols), MIN_BARS,
+            )
+            return {}
+        logger.info(
+            "[kline_backfill] smart repair: %d/%d symbols need backfill",
+            len(needs), len(symbols),
+        )
+        return self._fetch_and_save(needs, FULL_PERIOD, "YF_HIST")
+
+    def run_incremental(self, symbols: list[str]) -> dict[str, int]:
+        """Fetch last 5d of daily bars for all symbols (catches today's close)."""
+        logger.info("[kline_backfill] incremental update: %d symbols", len(symbols))
+        return self._fetch_and_save(symbols, INCREMENTAL_PERIOD, "YF_LIVE")
+
+    def run_full_cycle(self, symbols: list[str]) -> tuple[dict[str, int], dict[str, int]]:
+        """smart_repair then incremental — use this as the single idle entry point."""
+        repair = self.run_smart_repair(symbols)
+        incremental = self.run_incremental(symbols)
+        return repair, incremental


### PR DESCRIPTION
## Summary

- Adds  — , a WAL-mode async persistence layer optimised for high-frequency live trading writes
- Every quote cycle now persists  to  without blocking the main loop (async queue + background writer coroutine)
- Idle Task 5 in  runs  to move rows older than 30 days to 
- Fix: archive uses its own  so it does not contend with the writer thread (avoids )

## Key design decisions

| Decision | Rationale |
|----------|-----------|
| WAL +  | ~3-5x throughput vs default journal; safe for single-process use |
| Async queue + background writer | Caller never blocks on disk I/O; queue acts as pressure valve |
| Separate archive connection | Writer holds ; archive needs its own to avoid locking |
|  on  | PK is  — clustered access is faster |
|  drop guard | Prevents unbounded memory if writer falls behind |

## Test plan

- [x]  → 11 passed (verified locally)
- [ ] After merge + restart: confirm  grows each trading cycle
- [ ] Confirm  rows appear for active symbols
- [ ] Confirm archive table populated after first idle session

🤖 Generated with [Claude Code](https://claude.com/claude-code)