### PR TITLE
fix: LiveDbPersist auto-reconnect when kiro_quant.db inode is swapped

### DIFF
--- a/tests/test_db_persist.py
+++ b/tests/test_db_persist.py
@@ -237,3 +237,92 @@ class TestClose:
         asyncio.run(p.close())
         # Second close should be harmless
         asyncio.run(p.close())
+
+
+# -- Inode-change auto-reconnect (PR #85 follow-up) --
+
+
+class TestInodeReconnect:
+    def test_records_inode_on_init(self, tmp_db: Path):
+        """After _ensure_db the live conn's inode is captured."""
+        p = LiveDbPersist(str(tmp_db))
+        try:
+            import os
+            assert p._conn_inode == os.stat(str(tmp_db)).st_ino
+            assert p._reconnect_count == 0
+        finally:
+            asyncio.run(p.close())
+
+    def test_db_path_changed_detects_replacement(self, tmp_db: Path):
+        """If the file at db_path is replaced, _db_path_changed returns True."""
+        p = LiveDbPersist(str(tmp_db))
+        try:
+            # Simulate external replacement: delete original and create new file
+            tmp_db.unlink()
+            tmp_db.write_bytes(b"")  # Fresh inode at same path
+            assert p._db_path_changed() is True
+        finally:
+            asyncio.run(p.close())
+
+    def test_db_path_unchanged_when_file_untouched(self, tmp_db: Path):
+        p = LiveDbPersist(str(tmp_db))
+        try:
+            assert p._db_path_changed() is False
+        finally:
+            asyncio.run(p.close())
+
+    def test_db_path_changed_false_when_file_missing(self, tmp_db: Path):
+        """If file is deleted but not replaced, _db_path_changed is False (no current inode)."""
+        p = LiveDbPersist(str(tmp_db))
+        try:
+            tmp_db.unlink()
+            # No replacement yet → current_path_inode returns None → not "changed"
+            assert p._db_path_changed() is False
+        finally:
+            asyncio.run(p.close())
+
+    def test_reconnect_rebuilds_conn_with_new_inode(self, tmp_db: Path):
+        import os
+        p = LiveDbPersist(str(tmp_db))
+        try:
+            old_inode = p._conn_inode
+            # Simulate replacement
+            tmp_db.unlink()
+            tmp_db.write_bytes(b"")
+            reconnected = p._reconnect_if_path_changed()
+            assert reconnected is True
+            assert p._reconnect_count == 1
+            assert p._conn is not None
+            assert p._conn_inode == os.stat(str(tmp_db)).st_ino
+            assert p._conn_inode != old_inode
+        finally:
+            asyncio.run(p.close())
+
+    def test_batch_upsert_recovers_after_inode_swap(self, tmp_db: Path):
+        """Writes that would have gone to the orphan inode land in the new file after reconnect."""
+        cfg = PersistConfig(db_path=str(tmp_db), batch_size=10, flush_interval_sec=0.1)
+        p = LiveDbPersist(cfg=cfg)
+
+        async def _body():
+            await p.start()
+            await p.enqueue("AAPL", _make_df(n=2))
+            await asyncio.sleep(0.4)  # let first batch land in original file
+            # Simulate the bug: delete + replace kiro_quant.db while LiveDbPersist holds a conn
+            tmp_db.unlink()
+            tmp_db.write_bytes(b"")
+            await p.enqueue("AAPL", _make_df(n=3, symbol="AAPL"))
+            await asyncio.sleep(0.6)  # background writer should detect + reconnect
+            await p.close()
+
+        asyncio.run(_body())
+
+        # The new file should contain at least the post-swap rows
+        conn = sqlite3.connect(str(tmp_db))
+        try:
+            tables = [r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()]
+            assert "market_data" in tables, f"market_data table missing; tables={tables}"
+            rows = conn.execute("SELECT count(*) FROM market_data").fetchone()[0]
+        finally:
+            conn.close()
+        assert rows >= 3, f"Expected ≥3 rows after reconnect (got {rows}); writes were lost to orphan inode"
+        assert p._reconnect_count >= 1, "Reconnect was never triggered"

--- a/tests/test_kline_backfill.py
+++ b/tests/test_kline_backfill.py
@@ -162,30 +162,32 @@ class TestKlineBackfill:
         result = kb.symbols_needing_backfill(["AAPL"])
         assert result == ["AAPL"]
 
-    @patch("v3_pipeline.data.kline_backfill.KlineBackfill._fetch_and_save")
-    def test_run_smart_repair_skips_if_sufficient(self, mock_fetch, tmp_path):
+    @patch("v3_pipeline.data.kline_backfill.KlineBackfill._fetch_and_save_parallel")
+    @patch("v3_pipeline.data.kline_backfill.KlineBackfill._fetch_and_save_sequential")
+    def test_run_smart_repair_skips_if_sufficient(self, mock_seq, mock_par, tmp_path):
         kb = self._make_kb(tmp_path, "AAPL", MIN_BARS)
         result = kb.run_smart_repair(["AAPL"])
-        mock_fetch.assert_not_called()
+        mock_par.assert_not_called()
+        mock_seq.assert_not_called()
         assert result == {}
 
-    @patch("v3_pipeline.data.kline_backfill.KlineBackfill._fetch_and_save", return_value={"MSFT": 500})
-    def test_run_smart_repair_calls_fetch_for_missing(self, mock_fetch, tmp_path):
+    @patch("v3_pipeline.data.kline_backfill.KlineBackfill._fetch_and_save_sequential", return_value={"MSFT": 500})
+    def test_run_smart_repair_calls_fetch_for_missing(self, mock_seq, tmp_path):
+        # 1 symbol → ≤20 threshold → routes to _sequential (parallel only for >20 symbols)
         kb = self._make_kb(tmp_path)
         result = kb.run_smart_repair(["MSFT"])
-        mock_fetch.assert_called_once()
-        _, call_kwargs = mock_fetch.call_args
-        # period should be FULL_PERIOD, data_source YF_HIST
-        args = mock_fetch.call_args[0]
+        mock_seq.assert_called_once()
+        args = mock_seq.call_args[0]
         assert args[1] == "2y"
         assert args[2] == "YF_HIST"
 
-    @patch("v3_pipeline.data.kline_backfill.KlineBackfill._fetch_and_save", return_value={"AAPL": 5})
-    def test_run_incremental_always_fetches(self, mock_fetch, tmp_path):
+    @patch("v3_pipeline.data.kline_backfill.KlineBackfill._fetch_and_save_sequential", return_value={"AAPL": 5})
+    def test_run_incremental_always_fetches(self, mock_seq, tmp_path):
+        # run_incremental always uses sequential path regardless of max_workers
         kb = self._make_kb(tmp_path, "AAPL", MIN_BARS)
         result = kb.run_incremental(["AAPL"])
-        mock_fetch.assert_called_once()
-        args = mock_fetch.call_args[0]
+        mock_seq.assert_called_once()
+        args = mock_seq.call_args[0]
         assert args[1] == "5d"
         assert args[2] == "YF_LIVE"
 

--- a/v3_pipeline/data/db_persist.py
+++ b/v3_pipeline/data/db_persist.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta
@@ -74,6 +75,8 @@ class LiveDbPersist:
         if db_path:
             self.cfg.db_path = db_path
         self._conn: Optional[sqlite3.Connection] = None
+        self._conn_inode: Optional[int] = None  # inode the live conn was opened against
+        self._reconnect_count: int = 0
         self._queue: asyncio.Queue[_PendingRow | None] = asyncio.Queue()
         self._worker_task: Optional[asyncio.Task] = None
         self._closed = False
@@ -169,9 +172,57 @@ class LiveDbPersist:
 
     # ── Sync helpers (run via asyncio.to_thread) ───────────────────────────────
 
+    def _current_path_inode(self) -> Optional[int]:
+        """Return the inode of the file currently at cfg.db_path, or None if absent."""
+        try:
+            return os.stat(self.cfg.db_path).st_ino
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            logger.warning("[db_persist] stat(%s) failed: %s", self.cfg.db_path, exc)
+            return None
+
+    def _db_path_changed(self) -> bool:
+        """True when the on-disk path's inode no longer matches the live connection's inode.
+
+        Indicates the DB file was deleted, replaced, or moved out from under us — in
+        which case ``self._conn`` is now writing to an orphan inode and every commit
+        is silently lost. Caller should reopen via ``_reconnect_if_path_changed``.
+        """
+        if self._conn is None or self._conn_inode is None:
+            return False
+        current = self._current_path_inode()
+        return current is not None and current != self._conn_inode
+
+    def _reconnect_if_path_changed(self) -> bool:
+        """Detect a swapped inode and rebuild the connection.
+
+        Returns True when a reconnect happened. Safe to call from the writer thread
+        before each batch.
+        """
+        if not self._db_path_changed():
+            return False
+        self._reconnect_count += 1
+        logger.error(
+            "[db_persist] db_path inode changed (was=%s now=%s) — reconnecting (count=%d)",
+            self._conn_inode, self._current_path_inode(), self._reconnect_count,
+        )
+        # Close the old conn (still pointing to orphan inode); ignore errors
+        old = self._conn
+        self._conn = None
+        self._conn_inode = None
+        try:
+            if old is not None:
+                old.close()
+        except Exception:
+            pass
+        self._ensure_db()
+        return True
+
     def _ensure_db(self) -> None:
-        """Initialise DB, enable WAL, create tables if missing."""
+        """Initialise DB, enable WAL, create tables if missing. Records inode."""
         self._conn = sqlite3.connect(self.cfg.db_path, check_same_thread=False)
+        self._conn_inode = self._current_path_inode()
         self._conn.execute("PRAGMA journal_mode = WAL")
         self._conn.execute("PRAGMA synchronous = NORMAL")
         self._conn.execute(f"PRAGMA wal_autocheckpoint = {self.cfg.wal_checkpoint_pages}")
@@ -226,10 +277,15 @@ class LiveDbPersist:
                 pass
             self._conn.close()
             self._conn = None
+            self._conn_inode = None
 
     def _batch_upsert(self, rows: list[_PendingRow]) -> int:
         """Synchronous batch write inside the background worker."""
-        if not rows or self._conn is None:
+        if not rows:
+            return 0
+        # Detect a swapped inode (file deleted/replaced under us) and reopen before write
+        self._reconnect_if_path_changed()
+        if self._conn is None:
             return 0
         sql = """
             INSERT OR REPLACE INTO market_data


### PR DESCRIPTION
## Problem

Production runtime (PID 3398855, on \`feat/expand-universe-300\`) accumulated **274 phantom FDs to a deleted \`kiro_quant.db\` inode**. The file was replaced under the running launcher around 11:43 HKT; \`LiveDbPersist._conn\` kept committing to the orphan inode and every \`market_data\` write since then has been silently lost.

Evidence:
- \`/proc/3398855/fd\` shows 274 entries pointing to \`kiro_quant.db (deleted)\`.
- \`kiro_quant.db-wal\` mtime stopped at 11:44 despite \`IDLE_COLLECT\` still running at 17:49.
- \`kiro_quant.db\` main file is mtime 17:39 (touched by other code paths: \`DatabaseManager\` via \`kline_backfill\` and \`_archive_old_data_sync\` — both use \`with sqlite3.connect()\` context managers).

Root cause: \`LiveDbPersist\` opens one persistent \`self._conn\` for the lifetime of the process. SQLite holds the open inode even when the file is deleted/replaced. The conn keeps working at the FD level but writes go nowhere visible.

## Fix

Track the file's inode at open time and check it before every write:

- \`_ensure_db()\` records \`os.stat(db_path).st_ino\` into \`self._conn_inode\`.
- \`_db_path_changed()\` returns True when the current path resolves to a different inode (replacement) — False when the path is missing entirely (deletion without replacement, no recovery target).
- \`_reconnect_if_path_changed()\` closes the orphan conn and rebuilds via \`_ensure_db()\`.
- \`_batch_upsert()\` calls reconnect-check before every \`executemany\`, so the next batch after a swap lands in the new file instead of /dev/null.
- \`_close_conn()\` clears \`_conn_inode\` to keep state consistent.

A \`_reconnect_count\` counter is exposed for monitoring.

## Tests

- \`tests/test_db_persist.py\` — 6 new tests in \`TestInodeReconnect\`:
  - records inode on init
  - detects file replacement
  - distinguishes replacement vs pure deletion
  - rebuilds conn with new inode after reconnect
  - integration: writes recover after live inode swap (this is the real-world bug)
- \`tests/test_kline_backfill.py\` — fixed 3 stale mocks pointing to PR #85's renamed \`_fetch_and_save\` methods.

## Verification

\`\`\`
pytest tests/ --ignore=tests/test_pattern_trainer_components.py --ignore=tests/test_model_registry.py
571 passed, 1 skipped
\`\`\`

## Test plan
- [ ] Merge PR #85 first (this branches off it)
- [ ] After deploy + launcher restart, monitor for \`[db_persist] db_path inode changed\` log lines — should be rare; non-zero \`_reconnect_count\` indicates a live recovery
- [ ] Verify \`kiro_quant.db\` mtime advances normally even if external tools touch the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)