### PR TITLE
fix: DatabaseManager FD leak — close() connections instead of relying on GC

### DIFF
--- a/db_manager.py
+++ b/db_manager.py
@@ -2,6 +2,7 @@ import sqlite3
 import pandas as pd
 import os
 import logging
+from contextlib import closing
 from typing import Optional, List
 
 logger = logging.getLogger("DBManager")
@@ -15,7 +16,7 @@ class DatabaseManager:
 
     def _init_db(self):
         """Initialize the database and base table."""
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn, conn:
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS market_data (
                     symbol TEXT,
@@ -33,7 +34,7 @@ class DatabaseManager:
 
     def _ensure_columns(self, df: pd.DataFrame):
         """Ensure all columns in the DataFrame exist in the database table."""
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn, conn:
             cursor = conn.execute("PRAGMA table_info(market_data)")
             existing_cols = [row[1] for row in cursor.fetchall()]
             
@@ -66,7 +67,7 @@ class DatabaseManager:
         # Ensure schema matches
         self._ensure_columns(save_df)
         
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn, conn:
             # We use to_sql with a temporary table for UPSERT-like behavior in SQLite < 3.24
             # or just 'REPLACE' if we trust the primary key
             save_df.to_sql("market_data", conn, if_exists="append", index=False, method=self._upsert_method)
@@ -83,14 +84,14 @@ class DatabaseManager:
 
     def get_latest_data(self, symbol: str, limit: int = 100) -> pd.DataFrame:
         """Retrieve the latest entries for a symbol."""
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn, conn:
             query = f"SELECT * FROM market_data WHERE symbol = ? ORDER BY timestamp DESC LIMIT ?"
             return pd.read_sql_query(query, conn, params=(symbol, limit))
 
     def check_health(self, symbols: List[str]) -> dict:
         """Check the data range for each symbol and return a report of missing chunks."""
         report = {}
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn, conn:
             for sym in symbols:
                 cursor = conn.execute("SELECT MIN(timestamp), MAX(timestamp), COUNT(*) FROM market_data WHERE symbol = ?", (sym,))
                 min_t, max_t, count = cursor.fetchone()

--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -1,0 +1,171 @@
+"""
+Regression tests for db_manager.DatabaseManager — focused on the FD-leak
+that caused 275 live FDs to kiro_quant.db after 11min of KlineBackfill
+under PR #85's 300+ symbol universe (2026-05-16 production observation).
+
+Root cause: ``with sqlite3.connect(path) as conn`` is *transaction-managed*
+in Python — it commits/rolls back but does NOT close(). The connection
+sits open until garbage-collected, which under ThreadPoolExecutor never
+catches up. Fix is ``with closing(sqlite3.connect(...)) as conn, conn:``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# Make repo root importable so we can import db_manager
+_REPO = Path(__file__).resolve().parents[1]
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+from db_manager import DatabaseManager  # noqa: E402
+
+
+def _bars(n: int = 3, symbol: str = "AAPL") -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Date": pd.date_range("2026-05-16 09:30", periods=n, freq="min"),
+            "Open": [100.0 + i for i in range(n)],
+            "High": [101.0 + i for i in range(n)],
+            "Low": [99.0 + i for i in range(n)],
+            "Close": [100.5 + i for i in range(n)],
+            "Volume": [1_000_000] * n,
+            "symbol": [symbol] * n,
+        }
+    )
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> str:
+    return str(tmp_path / "test_kiro.db")
+
+
+# ── Functional ────────────────────────────────────────────────────────────────
+
+
+def test_init_creates_market_data_table(db_path):
+    DatabaseManager(db_path)
+    import sqlite3
+    with sqlite3.connect(db_path) as c:
+        tables = {r[0] for r in c.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert "market_data" in tables
+
+
+def test_save_data_inserts_rows(db_path):
+    db = DatabaseManager(db_path)
+    db.save_data(_bars(n=4))
+    import sqlite3
+    with sqlite3.connect(db_path) as c:
+        n = c.execute("SELECT COUNT(*) FROM market_data WHERE symbol='AAPL'").fetchone()[0]
+    assert n == 4
+
+
+def test_save_data_upserts_on_duplicate_key(db_path):
+    db = DatabaseManager(db_path)
+    db.save_data(_bars(n=2))
+    db.save_data(_bars(n=2))  # same timestamps
+    import sqlite3
+    with sqlite3.connect(db_path) as c:
+        n = c.execute("SELECT COUNT(*) FROM market_data WHERE symbol='AAPL'").fetchone()[0]
+    assert n == 2  # REPLACE, not append
+
+
+def test_save_data_adds_missing_columns(db_path):
+    db = DatabaseManager(db_path)
+    df = _bars()
+    df["RSI_14"] = 55.5
+    db.save_data(df)
+    import sqlite3
+    with sqlite3.connect(db_path) as c:
+        cols = {r[1] for r in c.execute("PRAGMA table_info(market_data)")}
+    assert "RSI_14" in cols
+
+
+def test_check_health_reports_per_symbol(db_path):
+    db = DatabaseManager(db_path)
+    db.save_data(_bars(n=3, symbol="AAPL"))
+    db.save_data(_bars(n=5, symbol="MSFT"))
+    report = db.check_health(["AAPL", "MSFT", "NVDA"])
+    assert report["AAPL"]["count"] == 3
+    assert report["MSFT"]["count"] == 5
+    assert report["NVDA"]["count"] == 0
+
+
+# ── FD leak regression ──────────────────────────────────────────────────────
+
+
+def _open_fds_to(path: str) -> int:
+    """Count FDs that the current process holds open against ``path``."""
+    fd_dir = Path("/proc/self/fd")
+    if not fd_dir.exists():
+        pytest.skip("/proc/self/fd not available on this platform")
+    n = 0
+    for fd in fd_dir.iterdir():
+        try:
+            target = os.readlink(fd)
+        except OSError:
+            continue  # FD vanished between listing and readlink
+        # Match either exact path or "<path> (deleted)" form
+        if target == path or target == f"{path} (deleted)":
+            n += 1
+    return n
+
+
+def test_save_data_does_not_leak_fds(db_path):
+    """100 sequential save_data calls must not leave 100 FDs open to the db."""
+    db = DatabaseManager(db_path)
+    baseline = _open_fds_to(db_path)
+    for i in range(100):
+        df = _bars(n=1, symbol=f"SYM{i:03d}")
+        db.save_data(df)
+    after = _open_fds_to(db_path)
+    # Allow ≤2 transient FDs (sqlite occasionally holds a wal companion)
+    assert after - baseline <= 2, (
+        f"FD leak: started with {baseline}, ended with {after} "
+        f"after 100 save_data calls"
+    )
+
+
+def test_parallel_save_data_does_not_leak_fds(db_path):
+    """ThreadPoolExecutor save_data x 60 must not leak 60+ FDs (production regression)."""
+    db = DatabaseManager(db_path)
+    baseline = _open_fds_to(db_path)
+
+    def _do(i: int):
+        df = _bars(n=2, symbol=f"PAR{i:03d}")
+        db.save_data(df)
+
+    with ThreadPoolExecutor(max_workers=4) as ex:
+        list(ex.map(_do, range(60)))
+    after = _open_fds_to(db_path)
+    # Under PR #85's 4-worker backfill this leaked 275 FDs in 11min; expect ≤5 now
+    assert after - baseline <= 5, (
+        f"Parallel FD leak: baseline={baseline} after={after} "
+        f"(was 275 in production with raw `with sqlite3.connect()`)"
+    )
+
+
+def test_get_latest_data_does_not_leak_fds(db_path):
+    db = DatabaseManager(db_path)
+    db.save_data(_bars(n=10))
+    baseline = _open_fds_to(db_path)
+    for _ in range(50):
+        _ = db.get_latest_data("AAPL", limit=10)
+    after = _open_fds_to(db_path)
+    assert after - baseline <= 2
+
+
+def test_check_health_does_not_leak_fds(db_path):
+    db = DatabaseManager(db_path)
+    db.save_data(_bars(n=3))
+    baseline = _open_fds_to(db_path)
+    for _ in range(50):
+        _ = db.check_health(["AAPL", "MSFT"])
+    after = _open_fds_to(db_path)
+    assert after - baseline <= 2


### PR DESCRIPTION
## Problem

Production runtime (PID 11286, fresh restart after PR #86 merge) accumulated **275 live FDs to kiro_quant.db within 11 min** — 252 of them opened in a single minute during the first KlineBackfill universe sweep. This is a **third, independent FD leak** on top of:
- PR #80 (yfinance Peewee SQLite singletons) — fixed
- PR #86 (LiveDbPersist inode swap) — fixed

Live FDs observed at 2026-05-16 20:47 HKT (uptime 11min, branch \`main\`):

| FD target | Count |
|-----------|-------|
| \`kiro_quant.db\` (live) | **275** |
| \`kiro_quant.db-wal\` (live) | 273 |
| \`tkr-tz.db\` (live) | 125 |
| \`tkr-tz.db-wal\` (live) | 124 |

## Root cause

\`db_manager.py\` uses \`with sqlite3.connect(path) as conn\` everywhere. Python's stdlib documents this is a **transaction** context manager — \`__exit__\` commits or rolls back but **never calls \`conn.close()\`**. The connection sits open until garbage-collected.

Under PR #85's \`ThreadPoolExecutor(max_workers=4)\` doing 69-symbol parallel \`save_data\`, GC cannot keep pace and FDs accumulate linearly. Restarting the launcher does not help — the leak restarts immediately.

## Fix

Wrap every \`sqlite3.connect(...)\` site in \`contextlib.closing()\` so the connection is guaranteed to close on scope exit, while preserving the inner \`, conn:\` for transaction semantics:

\`\`\`python
# before
with sqlite3.connect(self.db_path) as conn:
    ...

# after
with closing(sqlite3.connect(self.db_path)) as conn, conn:
    ...
\`\`\`

The multi-context-manager syntax means \`conn\` exits first (commit/rollback), then \`closing\` exits (close). Applied to all 5 call sites: \`_init_db\`, \`_ensure_columns\`, \`save_data\`, \`get_latest_data\`, \`check_health\`.

## Tests

New \`tests/test_db_manager.py\` — 9 tests:
- **5 functional**: init creates table, insert, upsert on duplicate PK, dynamic column add, per-symbol check_health.
- **4 FD-leak regressions** (the production failure mode):
  - \`test_save_data_does_not_leak_fds\` — 100 sequential save_data calls leave ≤2 FD growth (was 100)
  - \`test_parallel_save_data_does_not_leak_fds\` — 60 calls × 4 workers leave ≤5 FD growth (was 275 in production)
  - \`test_get_latest_data_does_not_leak_fds\`, \`test_check_health_does_not_leak_fds\` — read paths
  - All use \`/proc/self/fd\` counting; skip cleanly on non-Linux

## Verification

\`\`\`
pytest tests/ --ignore=tests/test_pattern_trainer_components.py --ignore=tests/test_model_registry.py
580 passed, 1 skipped
\`\`\`

## Remaining FD work (not in this PR)

- yfinance \`tkr-tz.db\` + \`tkr-tz.db-wal\` still grow at ~2.7/min under PR #85's 300+ symbol cadence even with PR #80's \`_reset_yf_cache_fds()\` — needs more aggressive reset or per-symbol cleanup. Separate branch: \`fix/yf-provider-aggressive-reset\`.

## Test plan
- [ ] After merge, restart launcher and verify FD count for \`kiro_quant.db\` stays under ~10 even during a full KlineBackfill universe sweep
- [ ] No regression in market_data row counts or schema migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)