### PR TITLE
fix: discover_accounts must call get_acc_list() with no kwargs

### DIFF
--- a/tests/test_futu_connector_unlock.py
+++ b/tests/test_futu_connector_unlock.py
@@ -78,26 +78,62 @@ def test_connect_auto_unlocks_in_real_mode(monkeypatch):
     assert connector.trade_ctx.unlock_calls == ["secret"]
 
 
-def test_discover_accounts_fallback_without_trd_env_support():
+def test_discover_accounts_uses_bare_get_acc_list():
+    """get_acc_list() takes no kwargs in any current SDK version. discover_accounts
+    must call it without trd_env or acc_id, otherwise the call raises TypeError and
+    discovered_accounts comes back empty (production bug, observed 2026-05-17)."""
     cfg = FutuConfig(trd_env="REAL", trade_password="secret")
     connector = FutuConnector(config=cfg)
     connector.ft = DummyFT
 
-    class LegacyTradeCtx(DummyTradeContext):
+    seen_kwargs: list[dict] = []
+
+    class StrictTradeCtx:
+        _acc_df = pd.DataFrame([{"acc_id": 123456}])
+
         def get_acc_list(self, **kwargs):
+            seen_kwargs.append(dict(kwargs))
+            # Real Futu SDK rejects ANY kwargs here
+            if kwargs:
+                raise TypeError(
+                    f"get_acc_list() got an unexpected keyword argument {next(iter(kwargs))!r}"
+                )
             return 0, self._acc_df
 
-    connector.trade_ctx = LegacyTradeCtx()
-
-    def fail_safe_trade_call(name, **kwargs):
-        raise TypeError("get_acc_list() got an unexpected keyword argument 'trd_env'")
-
-    connector._safe_trade_call = fail_safe_trade_call  # type: ignore[method-assign]
+    connector.trade_ctx = StrictTradeCtx()
 
     accounts = connector.discover_accounts()
 
+    assert seen_kwargs == [{}], f"discover_accounts must call get_acc_list() with no kwargs; got {seen_kwargs}"
     assert not accounts.empty
     assert int(accounts.iloc[0]["acc_id"]) == 123456
+
+
+def test_discover_accounts_returns_empty_on_total_failure():
+    """If get_acc_list itself raises (network, unauth, etc.), discover_accounts swallows
+    the error and returns an empty frame instead of crashing the launcher."""
+    cfg = FutuConfig(trd_env="SIMULATE", trade_password="secret")
+    connector = FutuConnector(config=cfg)
+    connector.ft = DummyFT
+
+    class DeadCtx:
+        def get_acc_list(self):
+            raise RuntimeError("trade ctx not connected")
+
+    connector.trade_ctx = DeadCtx()
+
+    accounts = connector.discover_accounts()
+    assert accounts.empty
+
+
+def test_discover_accounts_skips_when_not_connected():
+    cfg = FutuConfig(trd_env="SIMULATE")
+    connector = FutuConnector(config=cfg)
+    connector.ft = DummyFT
+    connector.trade_ctx = None
+
+    accounts = connector.discover_accounts()
+    assert accounts.empty
 
 
 def test_connect_does_not_unlock_in_simulate_mode(monkeypatch):

--- a/v3_pipeline/core/futu_connector.py
+++ b/v3_pipeline/core/futu_connector.py
@@ -499,23 +499,20 @@ class FutuConnector:
         self.logger.info("Trading unlocked successfully")
 
     def discover_accounts(self) -> pd.DataFrame:
+        # Futu's get_acc_list() does NOT accept trd_env or acc_id kwargs — it
+        # returns ALL accounts the trade context can see, and downstream code
+        # filters by market/acc_id. Calling it via _safe_trade_call (which
+        # always injects trd_env=) or with acc_id (the prior TypeError fallback)
+        # produces "got an unexpected keyword argument" on every SDK version
+        # since 6.x, leaving discovered_accounts empty.
+        if self.trade_ctx is None or self.ft is None:
+            self.logger.warning("Account discovery skipped: FutuConnector not connected")
+            self.discovered_accounts = pd.DataFrame()
+            return self.discovered_accounts
         try:
-            data = self._safe_trade_call("get_acc_list")
-        except TypeError as exc:
-            if "trd_env" not in str(exc):
-                self.logger.warning("Account discovery failed: %s", exc)
-                self.discovered_accounts = pd.DataFrame()
-                return self.discovered_accounts
-            try:
-                if self.trade_ctx is None or self.ft is None:
-                    raise RuntimeError("FutuConnector not connected")
-                ret, data = self.trade_ctx.get_acc_list(**self._account_kwargs())
-                if ret != self.ft.RET_OK:
-                    raise RuntimeError(self._build_trade_error("get_acc_list failed", data))
-            except Exception as fallback_exc:
-                self.logger.warning("Account discovery failed: %s", fallback_exc)
-                self.discovered_accounts = pd.DataFrame()
-                return self.discovered_accounts
+            ret, data = self.trade_ctx.get_acc_list()
+            if ret != self.ft.RET_OK:
+                raise RuntimeError(self._build_trade_error("get_acc_list failed", data))
         except Exception as exc:
             self.logger.warning("Account discovery failed: %s", exc)
             self.discovered_accounts = pd.DataFrame()


### PR DESCRIPTION
## Problem

Cron health report (2026-05-17) shows the warning every cycle:

\`get_acc_list() got an unexpected keyword argument 'acc_id'\`

→ \`discovered_accounts\` ends up empty → per-market \`acc_id\` routing falls back to the global US acc_id even for HK positions (re-opens the bug class PR #72 was meant to close).

## Root cause

Current Futu SDK's \`get_acc_list()\` takes **no** keyword arguments. The old discovery flow:

1. \`_safe_trade_call(\"get_acc_list\")\` always injects \`trd_env=\` → \`TypeError\` mentioning \`trd_env\`.
2. The narrow \`except TypeError if 'trd_env' in str(exc):\` retried with \`get_acc_list(**self._account_kwargs())\` which injects \`acc_id=\` → \`TypeError\` mentioning \`acc_id\`.
3. Outer \`except Exception\` wipes \`discovered_accounts\` to empty without surfacing why.

## Fix

\`discover_accounts()\` now calls \`self.trade_ctx.get_acc_list()\` directly with no kwargs. Connection-not-ready short-circuits early; any runtime failure returns an empty frame and logs the error instead of crashing the launcher.

## Tests

\`tests/test_futu_connector_unlock.py\` updated:

- **test_discover_accounts_uses_bare_get_acc_list** — asserts \`seen_kwargs == [{}]\`. Mock context raises the production \`TypeError\` if any kwarg is passed.
- **test_discover_accounts_returns_empty_on_total_failure** — graceful degradation when ctx raises.
- **test_discover_accounts_skips_when_not_connected** — no crash before connect().

## Verification

\`\`\`
pytest tests/test_futu_connector_unlock.py tests/test_multi_market_isolation.py tests/test_account_routing.py
64 passed
\`\`\`

Full suite (excluding pre-existing test_pattern_trainer_components / test_model_registry): 581 passed. The only new failure (\`test_dynamic_watchlist_format\`) is unrelated — it's a PR #85 test that fails because a daily screener cron rewrites \`dynamic_watchlist.json\` without the \`version\` field on the live runtime; not introduced or affected by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)