### PR TITLE
fix: yf_provider treats N/A and other sentinel strings as missing price data

### DIFF
--- a/tests/test_yf_provider.py
+++ b/tests/test_yf_provider.py
@@ -470,6 +470,98 @@ class TestResetYfCacheFds:
         assert len(reset_calls) == 5
 
 
+# ── N/A / sentinel price sanitisation (E18 — US after-hours) ─────────────────
+
+class TestNonNumericPriceSanitisation:
+    """Sentinel quote payloads ("N/A", "—", "") must surface as None, not raise."""
+
+    def _na_history_df(self, close="N/A"):
+        return pd.DataFrame({
+            "Open": [100.0], "High": [101.0], "Low": [99.0],
+            "Close": [close], "Volume": [1000.0],
+        })
+
+    def test_close_na_string_returns_none(self):
+        from v3_pipeline.data import yf_provider
+
+        with patch.object(yf_provider, "_get_fd_stats", return_value=(100, 1024)):
+            with patch("yfinance.Ticker") as mock_ticker:
+                mock_ticker.return_value.history.return_value = self._na_history_df("N/A")
+                result = yf_provider.get_latest_quote("AAPL")
+        assert result is None, "N/A close must not become a quote"
+
+    def test_close_em_dash_returns_none(self):
+        from v3_pipeline.data import yf_provider
+
+        with patch.object(yf_provider, "_get_fd_stats", return_value=(100, 1024)):
+            with patch("yfinance.Ticker") as mock_ticker:
+                mock_ticker.return_value.history.return_value = self._na_history_df("—")
+                result = yf_provider.get_latest_quote("AAPL")
+        assert result is None
+
+    def test_close_nan_returns_none(self):
+        from v3_pipeline.data import yf_provider
+
+        with patch.object(yf_provider, "_get_fd_stats", return_value=(100, 1024)):
+            with patch("yfinance.Ticker") as mock_ticker:
+                mock_ticker.return_value.history.return_value = self._na_history_df(float("nan"))
+                result = yf_provider.get_latest_quote("AAPL")
+        assert result is None
+
+    def test_close_empty_string_returns_none(self):
+        from v3_pipeline.data import yf_provider
+
+        with patch.object(yf_provider, "_get_fd_stats", return_value=(100, 1024)):
+            with patch("yfinance.Ticker") as mock_ticker:
+                mock_ticker.return_value.history.return_value = self._na_history_df("")
+                result = yf_provider.get_latest_quote("AAPL")
+        assert result is None
+
+    def test_numeric_string_still_parses(self):
+        from v3_pipeline.data import yf_provider
+
+        df = pd.DataFrame({
+            "Open": ["100.5"], "High": ["101.5"], "Low": ["99.5"],
+            "Close": ["100.75"], "Volume": ["50000"],
+        })
+        with patch.object(yf_provider, "_get_fd_stats", return_value=(100, 1024)):
+            with patch("yfinance.Ticker") as mock_ticker:
+                mock_ticker.return_value.history.return_value = df
+                result = yf_provider.get_latest_quote("AAPL")
+        assert result is not None
+        assert result["Close"] == 100.75
+        assert result["Open"] == 100.5
+
+    def test_partial_na_falls_back_to_close(self):
+        from v3_pipeline.data import yf_provider
+
+        df = pd.DataFrame({
+            "Open": ["N/A"], "High": ["N/A"], "Low": ["N/A"],
+            "Close": [100.5], "Volume": [1000.0],
+        })
+        with patch.object(yf_provider, "_get_fd_stats", return_value=(100, 1024)):
+            with patch("yfinance.Ticker") as mock_ticker:
+                mock_ticker.return_value.history.return_value = df
+                result = yf_provider.get_latest_quote("AAPL")
+        assert result is not None
+        assert result["Close"] == 100.5
+        assert result["Open"] == 100.5
+        assert result["High"] == 100.5
+        assert result["Low"] == 100.5
+
+    def test_coerce_price_helper_directly(self):
+        from v3_pipeline.data.yf_provider import _coerce_price
+        assert _coerce_price(100.5, field="x", symbol="T") == 100.5
+        assert _coerce_price("100.5", field="x", symbol="T") == 100.5
+        assert _coerce_price("N/A", field="x", symbol="T") is None
+        assert _coerce_price("n/a", field="x", symbol="T") is None
+        assert _coerce_price("  N/A  ", field="x", symbol="T") is None
+        assert _coerce_price(None, field="x", symbol="T") is None
+        assert _coerce_price(float("nan"), field="x", symbol="T") is None
+        assert _coerce_price("—", field="x", symbol="T") is None
+        assert _coerce_price("garbage", field="x", symbol="T") is None
+
+
 # ── 10 consecutive IDLE backfill rounds — FD stability ───────────────────────
 
 class TestIdleBackfillFdStability:

--- a/v3_pipeline/data/yf_provider.py
+++ b/v3_pipeline/data/yf_provider.py
@@ -92,6 +92,48 @@ def _is_fd_safe() -> tuple[bool, dict]:
 
 # ── Internal helpers ───────────────────────────────────────────────────────────
 
+# Tokens that quote providers occasionally return in place of a numeric price,
+# especially during US after-hours / halt windows. Anything matching these
+# (case-insensitive, whitespace-trimmed) is treated as missing data and forces
+# the provider to return None so downstream code can fall back instead of
+# crashing on `float("N/A")`.
+_NON_NUMERIC_PRICE_TOKENS = frozenset({"", "N/A", "NA", "NAN", "NONE", "NULL", "—", "-", "--", "?"})
+
+
+def _coerce_price(value, *, field: str, symbol: str) -> Optional[float]:
+    """Convert ``value`` to a float or return None if it is a sentinel/non-numeric.
+
+    Logs at WARNING when a non-numeric token is rejected so operators see why
+    a bar was dropped. Returns None when the value is missing or unparseable.
+    """
+    if value is None:
+        return None
+    # pandas/numpy NaN
+    try:
+        import math
+        if isinstance(value, float) and math.isnan(value):
+            return None
+    except Exception:
+        pass
+    if isinstance(value, (int, float)):
+        return float(value)
+    s = str(value).strip()
+    if s.upper() in _NON_NUMERIC_PRICE_TOKENS:
+        logger.warning(
+            "[yf_provider] %s non-numeric %s=%r — treating as missing data",
+            symbol, field, value,
+        )
+        return None
+    try:
+        return float(s)
+    except (TypeError, ValueError):
+        logger.warning(
+            "[yf_provider] %s unparseable %s=%r — treating as missing data",
+            symbol, field, value,
+        )
+        return None
+
+
 def _close_ticker_session(ticker) -> None:
     """Close the underlying requests session of a yfinance Ticker.
 
@@ -175,14 +217,24 @@ def get_latest_quote(symbol: str) -> Optional[dict]:
                 logger.warning("[yf_provider] empty history for %s", symbol)
                 return None
             row = hist.iloc[-1]
-            close = float(row.get("Close", 0.0))
+            # Sanitise: providers occasionally return "N/A" or "—" for after-hours
+            # bars; let _coerce_price reject those so callers fall back cleanly
+            # instead of raising `ValueError: could not convert string to float`
+            # in the order-builder.
+            close = _coerce_price(row.get("Close"), field="Close", symbol=symbol)
+            if close is None:
+                return None
+            open_v = _coerce_price(row.get("Open"), field="Open", symbol=symbol)
+            high_v = _coerce_price(row.get("High"), field="High", symbol=symbol)
+            low_v = _coerce_price(row.get("Low"), field="Low", symbol=symbol)
+            volume = _coerce_price(row.get("Volume"), field="Volume", symbol=symbol)
             result = {
                 "Date": pd.Timestamp.now(),
-                "Open": float(row.get("Open", close)),
-                "High": float(row.get("High", close)),
-                "Low": float(row.get("Low", close)),
+                "Open": open_v if open_v is not None else close,
+                "High": high_v if high_v is not None else close,
+                "Low": low_v if low_v is not None else close,
                 "Close": close,
-                "Volume": float(row.get("Volume", 0.0)),
+                "Volume": volume if volume is not None else 0.0,
                 "data_source": "YF_LIVE",
             }
             return result


### PR DESCRIPTION
## Problem

E18 production incident: \`ValueError: could not convert string to float: 'N/A'\` raised in the order-builder during US after-hours. The centralised yfinance provider returned a dict with \`Close=\"N/A\"\` (a literal sentinel some providers ship outside RTH), and downstream \`float(close)\` blew up. The engine reverted cleanly, but the root cause stayed unfixed — every after-hours fetch could fault the same way.

## Fix

Add \`_coerce_price()\` to \`v3_pipeline/data/yf_provider.py\`:
- Returns None for None, NaN, empty string, \`N/A\` / \`NA\` / \`NAN\` / \`NONE\` / \`NULL\`, em-dash \`—\`, \`-\`, \`--\`, \`?\` (case-insensitive, whitespace-trimmed).
- Parses numeric strings (\`\"100.5\"\`) via \`float()\`.
- Logs WARNING with field name and symbol when a sentinel is rejected so operators see why a bar was dropped.

\`get_latest_quote()\` flow:
- If Close coerces to None → return None for the whole quote (caller falls back to cache/Futu).
- If Open/High/Low coerce to None but Close is good → default each to Close (matches the prior behaviour of \`row.get(\"Open\", close)\`).
- Volume defaults to 0.0 when missing.

## Tests

7 new in \`TestNonNumericPriceSanitisation\`:
- Close = \`N/A\` / \`—\` / \`NaN\` / \`\"\"\` → result is None
- Numeric-string roundtrip → \"100.5\" → 100.5
- Partial NA on Open/High/Low → fallback to Close
- \`_coerce_price\` helper direct unit test (variants, whitespace, None, garbage)

Plus 36 existing yf_provider tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)