### PR TITLE
fix: yf_provider resets cache FDs every N symbols inside download_history

### DIFF
--- a/tests/test_yf_provider.py
+++ b/tests/test_yf_provider.py
@@ -397,7 +397,7 @@ class TestResetYfCacheFds:
         assert len(reset_calls) == 1
 
     def test_called_in_download_history_finally(self):
-        """_reset_yf_cache_fds is invoked once after every download_history call."""
+        """_reset_yf_cache_fds is invoked at least once per download_history call (batch tail)."""
         from v3_pipeline.data import yf_provider
 
         reset_calls = []
@@ -413,7 +413,61 @@ class TestResetYfCacheFds:
                     mock_ticker.return_value.history.return_value = _fake_history_df()
                     yf_provider.download_history(["AAPL", "MSFT"])
 
-        assert len(reset_calls) == 1  # once per batch, not per symbol
+        # 2 symbols + _RESET_EVERY default 5 → only the tail-finally reset fires
+        assert len(reset_calls) == 1
+
+    def test_reset_fires_every_N_symbols_in_download_history(self):
+        """With _RESET_EVERY=2, a 7-symbol batch must reset 3× in-loop + 1× tail = 4."""
+        from v3_pipeline.data import yf_provider
+
+        reset_calls = []
+        original = yf_provider._reset_yf_cache_fds
+
+        def _spy():
+            reset_calls.append(1)
+            original()
+
+        with patch.object(yf_provider, "_RESET_EVERY", 2):
+            with patch.object(yf_provider, "_reset_yf_cache_fds", side_effect=_spy):
+                with patch.object(yf_provider, "_get_fd_stats", return_value=(100, 1024)):
+                    with patch("yfinance.Ticker") as mock_ticker:
+                        mock_ticker.return_value.history.return_value = _fake_history_df()
+                        yf_provider.download_history([f"S{i}" for i in range(7)])
+
+        # 7 symbols / RESET_EVERY=2 → in-loop resets at idx 2,4,6 = 3 calls
+        # plus the finally-tail reset → 4 total
+        assert len(reset_calls) == 4, f"expected 4 resets (3 in-loop + 1 tail), got {len(reset_calls)}"
+
+    def test_reset_does_not_skip_when_exception_in_loop(self):
+        """Even if some symbols raise, in-loop reset still triggers (finally guard)."""
+        from v3_pipeline.data import yf_provider
+
+        reset_calls = []
+        original = yf_provider._reset_yf_cache_fds
+
+        def _spy():
+            reset_calls.append(1)
+            original()
+
+        call_count = {"n": 0}
+
+        def _make_ticker(*a, **kw):
+            call_count["n"] += 1
+            t = MagicMock()
+            if call_count["n"] % 3 == 0:  # every 3rd symbol raises during history()
+                t.history.side_effect = RuntimeError("yf timeout")
+            else:
+                t.history.return_value = _fake_history_df()
+            return t
+
+        with patch.object(yf_provider, "_RESET_EVERY", 1):
+            with patch.object(yf_provider, "_reset_yf_cache_fds", side_effect=_spy):
+                with patch.object(yf_provider, "_get_fd_stats", return_value=(100, 1024)):
+                    with patch("yfinance.Ticker", side_effect=_make_ticker):
+                        yf_provider.download_history(["A", "B", "C", "D"])
+
+        # RESET_EVERY=1 → reset every symbol = 4 in-loop + 1 tail = 5
+        assert len(reset_calls) == 5
 
 
 # ── 10 consecutive IDLE backfill rounds — FD stability ───────────────────────

--- a/v3_pipeline/data/yf_provider.py
+++ b/v3_pipeline/data/yf_provider.py
@@ -28,6 +28,12 @@ logger = logging.getLogger("kiro.yf_provider")
 _MAX_CONCURRENT = int(os.getenv("YF_MAX_CONCURRENT", "1"))
 _semaphore = threading.Semaphore(_MAX_CONCURRENT)
 _FD_GUARD_THRESHOLD = float(os.getenv("YF_FD_GUARD_THRESHOLD", "0.80"))
+# Cap per-batch FD growth in download_history. Default 5 → reset the yfinance
+# Peewee SQLite singletons every N symbols inside the loop instead of only at
+# batch end. Without this cap, a 300-symbol IDLE round can balloon FD count
+# even with PR #80's per-batch reset because yfinance reopens its tz/cookie
+# cache db on every Ticker.history() call.
+_RESET_EVERY = max(1, int(os.getenv("YF_RESET_EVERY", "5")))
 
 
 # ── FD utilities ──────────────────────────────────────────────────────────────
@@ -218,7 +224,7 @@ def download_history(
     with _semaphore:
         try:
             import yfinance as yf
-            for sym in symbols:
+            for idx, sym in enumerate(symbols, start=1):
                 ticker = None
                 try:
                     ticker = yf.Ticker(sym)
@@ -230,10 +236,15 @@ def download_history(
                 finally:
                     if ticker is not None:
                         _close_ticker_session(ticker)
+                    # Aggressive reset every N symbols inside the loop to bound
+                    # tkr-tz.db FD growth under PR #85's 300+ symbol universe.
+                    if idx % _RESET_EVERY == 0:
+                        _reset_yf_cache_fds()
         except Exception as exc:
             logger.warning("[yf_provider] download_history error: %s", exc)
             for s in symbols:
                 results.setdefault(s, pd.DataFrame())
         finally:
+            # Final reset to catch the tail of the loop (when len(symbols) % _RESET_EVERY != 0)
             _reset_yf_cache_fds()
     return results


### PR DESCRIPTION
## Problem

PR #80's \`_reset_yf_cache_fds()\` was wired into the **batch-tail** \`finally\` of \`download_history()\` — fired once per call. Under PR #85's 300+ symbol universe + KlineBackfill's \`ThreadPoolExecutor(max_workers=4)\`, yfinance reopens its Peewee SQLite caches (\`tkr-tz.db\`, \`cookies.db\`, \`isin.db\`) on every \`Ticker.history()\` call faster than the per-batch reset can keep pace.

Live production evidence (launcher PID 11286, 2026-05-16 20:47 HKT, only 11min uptime):

| FD target | Count |
|-----------|-------|
| \`tkr-tz.db\` | **815** |
| \`tkr-tz.db-wal\` | **332** |

## Fix

Add \`_RESET_EVERY\` (default 5, env \`YF_RESET_EVERY\`) and trigger \`_reset_yf_cache_fds()\` **inside** the per-symbol \`finally\` block whenever \`idx % _RESET_EVERY == 0\`. The tail-finally reset is preserved so partial batches still get cleaned up.

This bounds per-batch FD growth at \`O(_RESET_EVERY)\` regardless of batch size. The extra cost is one Peewee \`set_location\` per 5 symbols, which is negligible against the per-call yfinance.history HTTP overhead.

## Tests

- \`test_called_in_download_history_finally\` — adjusted: 2 symbols + default RESET_EVERY=5 → only the tail-finally reset fires → 1 call.
- **NEW** \`test_reset_fires_every_N_symbols_in_download_history\` — patches \`_RESET_EVERY=2\`, downloads 7 symbols → resets at idx 2, 4, 6 (3 in-loop) + 1 tail = 4 total.
- **NEW** \`test_reset_does_not_skip_when_exception_in_loop\` — patches \`_RESET_EVERY=1\` with some symbols raising mid-loop; reset still fires via the \`finally\` guard.

\`pytest tests/test_yf_provider.py\` → 31 passed.

## Tunability

Operators can raise reset cadence via env:

\`\`\`bash
YF_RESET_EVERY=2 python3 v3_launcher.py    # more aggressive
YF_RESET_EVERY=10 python3 v3_launcher.py   # lighter, larger FD ceiling
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)