### PR TITLE
fix: V3FunnelScreener preserves tiered watchlist schema on rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ trades.jsonl
 
 # Root-level model output (training artifacts separate from v3_pipeline/models/)
 /models/
+
+# Legacy scripts (moved from root, kept for reference)
+legacy_archive/v3_scripts/ # not tracked

--- a/tests/test_screener_watchlist_merge.py
+++ b/tests/test_screener_watchlist_merge.py
@@ -1,0 +1,162 @@
+"""
+Regression for V3FunnelScreener.run() — must preserve the tiered schema added
+by PR #85 (`version`, `tiers.{tier1,tier2,tier3}`, `metadata`) when it
+rewrites `dynamic_watchlist.json`, instead of clobbering it with a flat
+`{date, picks, details, failed_symbols}` payload.
+
+Production failure: tests/test_universe_expansion.py::test_dynamic_watchlist_format
+fails every morning because the screener cron at ~08:00 HKT replaces the file
+with the old schema, dropping `version`/`tiers`/`metadata`.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+
+# tests/test_idle_collect.py installs a `SimpleNamespace(V3FunnelScreener=object)`
+# stub into sys.modules via setdefault. Once that ran in the same process, any
+# later `from v3_pipeline.features.screener import V3FunnelScreener` returns the
+# bare `object` class and our `V3FunnelScreener(watchlist_path=...)` call dies
+# with `TypeError: object() takes no arguments`. Force-reload the real module
+# here so this file works regardless of test-collection order.
+sys.modules.pop("v3_pipeline.features.screener", None)
+_screener_mod = importlib.import_module("v3_pipeline.features.screener")
+V3FunnelScreener = _screener_mod.V3FunnelScreener
+
+
+def _seed_tiered_watchlist(path: Path, picks_in_tier1: list[str]) -> dict:
+    payload = {
+        "version": "2.0",
+        "date": "2026-05-16 08:00:00",
+        "expanded_universe": False,
+        "tiers": {
+            "tier1": {
+                "description": "Active trading",
+                "max_size": 20,
+                "symbols": list(picks_in_tier1),
+            },
+            "tier2": {"description": "Full universe", "count": 300, "symbols": []},
+            "tier3": {"description": "Watch only", "symbols": []},
+        },
+        "metadata": {"last_screened_at": "2026-05-16 08:00:00", "picks_count": len(picks_in_tier1)},
+    }
+    path.write_text(json.dumps(payload, indent=4))
+    return payload
+
+
+def _fake_screener_df(picks: list[str]) -> pd.DataFrame:
+    return pd.DataFrame([
+        {
+            "symbol": s, "pe": 20.0, "eps_growth": 0.3, "rev_growth": 0.2,
+            "peg": 1.0, "price": 100.0, "ma50": 95.0,
+        }
+        for s in picks
+    ])
+
+
+class TestScreenerPreservesTieredSchema:
+    def test_run_keeps_version_tiers_metadata_when_file_exists(self, tmp_path):
+        path = tmp_path / "dynamic_watchlist.json"
+        _seed_tiered_watchlist(path, picks_in_tier1=["OLD1", "OLD2"])
+
+        scr = V3FunnelScreener(watchlist_path=str(path))
+        scr.watchlist_path = path  # override to tmp
+
+        picks = ["NEW1", "NEW2", "NEW3"]
+        with patch.object(scr, "fetch_data", return_value=_fake_screener_df(picks)):
+            returned = scr.run(symbols=picks)
+
+        assert returned == picks
+        with open(path) as f:
+            data = json.load(f)
+        # Schema PR #85 expects
+        assert "version" in data
+        assert data["version"] == "2.0"
+        assert "tiers" in data
+        assert "tier1" in data["tiers"]
+        assert "tier2" in data["tiers"]
+        assert "tier3" in data["tiers"]
+        assert "metadata" in data
+        # Tier1 was updated with the new picks (replacing OLD1/OLD2)
+        assert data["tiers"]["tier1"]["symbols"] == picks
+        # Legacy fields still populated
+        assert data["picks"] == picks
+
+    def test_run_builds_schema_when_file_missing(self, tmp_path):
+        path = tmp_path / "dynamic_watchlist.json"
+        assert not path.exists()
+
+        scr = V3FunnelScreener(watchlist_path=str(path))
+        scr.watchlist_path = path
+
+        picks = ["A", "B"]
+        with patch.object(scr, "fetch_data", return_value=_fake_screener_df(picks)):
+            scr.run(symbols=picks)
+
+        with open(path) as f:
+            data = json.load(f)
+        assert "version" in data
+        assert "tiers" in data
+        assert "metadata" in data
+        assert data["tiers"]["tier1"]["symbols"] == picks
+
+    def test_run_caps_tier1_at_max_size(self, tmp_path):
+        path = tmp_path / "dynamic_watchlist.json"
+        _seed_tiered_watchlist(path, picks_in_tier1=[])
+        # Override max_size
+        with open(path) as f:
+            d = json.load(f)
+        d["tiers"]["tier1"]["max_size"] = 3
+        path.write_text(json.dumps(d))
+
+        scr = V3FunnelScreener(watchlist_path=str(path))
+        scr.watchlist_path = path
+        picks = [f"S{i}" for i in range(10)]
+        with patch.object(scr, "fetch_data", return_value=_fake_screener_df(picks)):
+            scr.run(symbols=picks)
+
+        with open(path) as f:
+            data = json.load(f)
+        assert len(data["tiers"]["tier1"]["symbols"]) == 3
+        assert data["tiers"]["tier1"]["symbols"] == picks[:3]
+        # The full picks array still preserved at top level for legacy callers
+        assert data["picks"] == picks
+
+    def test_run_recovers_when_existing_file_corrupted(self, tmp_path):
+        path = tmp_path / "dynamic_watchlist.json"
+        path.write_text("not valid json {{{")
+
+        scr = V3FunnelScreener(watchlist_path=str(path))
+        scr.watchlist_path = path
+        picks = ["A"]
+        with patch.object(scr, "fetch_data", return_value=_fake_screener_df(picks)):
+            scr.run(symbols=picks)
+
+        with open(path) as f:
+            data = json.load(f)
+        # Even with a corrupted existing file, the schema is rebuilt cleanly
+        assert "version" in data and "tiers" in data and "metadata" in data
+
+    def test_metadata_records_screener_run(self, tmp_path):
+        path = tmp_path / "dynamic_watchlist.json"
+        _seed_tiered_watchlist(path, picks_in_tier1=[])
+
+        scr = V3FunnelScreener(watchlist_path=str(path))
+        scr.watchlist_path = path
+        with patch.object(scr, "fetch_data", return_value=_fake_screener_df(["X", "Y"])):
+            scr.run(symbols=["X", "Y"])
+
+        with open(path) as f:
+            data = json.load(f)
+        meta = data["metadata"]
+        assert meta["last_screener"] == "V3FunnelScreener"
+        assert meta["picks_count"] == 2
+        assert "last_screened_at" in meta

--- a/v3_pipeline/features/screener.py
+++ b/v3_pipeline/features/screener.py
@@ -345,16 +345,73 @@ class V3FunnelScreener:
         df = self.filter_by_growth(df)
         df = self.filter_by_valuation(df)
         df = self.filter_by_trend(df)
-        
+
+        picks = df['symbol'].tolist()
+        details = df.to_dict(orient="records")
+        failed = getattr(self, '_failed_symbols', [])
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        # Preserve the tiered schema written by v3_pipeline/config/universe.py and
+        # asserted by tests/test_universe_expansion.py::test_dynamic_watchlist_format.
+        # Load whatever's already there, merge in today's picks (push them into
+        # tier1.symbols + the legacy top-level `picks` array), and keep version /
+        # tiers / metadata so PR #85's universe loader doesn't fall back to legacy.
+        existing: dict = {}
+        try:
+            if self.watchlist_path.exists():
+                with open(self.watchlist_path, "r", encoding="utf-8") as f:
+                    existing = json.load(f) or {}
+        except (OSError, json.JSONDecodeError):
+            existing = {}
+
+        tiers = existing.get("tiers")
+        if not isinstance(tiers, dict):
+            tiers = {
+                "tier1": {
+                    "description": "Active trading — screener picks, model evaluation, order execution",
+                    "max_size": 20,
+                    "symbols": [],
+                },
+                "tier2": {
+                    "description": "Full universe — data collection, backfill, indicator computation",
+                    "count": 0,
+                    "symbols": [],
+                },
+                "tier3": {
+                    "description": "Watch only — symbols pending promotion / under review",
+                    "symbols": [],
+                },
+            }
+
+        tier1 = tiers.setdefault("tier1", {"description": "Active trading", "max_size": 20, "symbols": []})
+        max_size = int(tier1.get("max_size", 20) or 20)
+        tier1["symbols"] = picks[:max_size]
+        tiers["tier1"] = tier1
+        tiers.setdefault("tier2", {"description": "Full universe", "count": 0, "symbols": []})
+        tiers.setdefault("tier3", {"description": "Watch only", "symbols": []})
+
+        metadata = existing.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = {}
+        metadata["last_screened_at"] = now
+        metadata["last_screener"] = "V3FunnelScreener"
+        metadata["picks_count"] = len(picks)
+        metadata["failed_count"] = len(failed)
+
         results = {
-            "date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-            "picks": df['symbol'].tolist(),
-            "details": df.to_dict(orient="records"),
-            "failed_symbols": getattr(self, '_failed_symbols', [])
+            "version": existing.get("version", "2.0"),
+            "date": now,
+            "expanded_universe": bool(existing.get("expanded_universe", False)),
+            "tiers": tiers,
+            "metadata": metadata,
+            # Legacy fields retained for backward compatibility with older callers
+            "picks": picks,
+            "details": details,
+            "failed_symbols": failed,
         }
-        
+
         with open(self.watchlist_path, "w") as f:
             json.dump(results, f, indent=4)
-        
-        print(f"[V3FunnelScreener] Screening complete. {len(results['picks'])} picks saved to {self.watchlist_path}")
-        return results['picks']
+
+        print(f"[V3FunnelScreener] Screening complete. {len(picks)} picks saved to {self.watchlist_path}")
+        return picks


### PR DESCRIPTION
## Problem

\`tests/test_universe_expansion.py::test_dynamic_watchlist_format\` (PR #85) fails every morning. The daily screener cron runs \`V3FunnelScreener.run()\` at ~08:00 HKT and rewrites \`dynamic_watchlist.json\` with the flat legacy schema \`{date, picks, details, failed_symbols}\`, dropping PR #85's \`version\` / \`tiers.{tier1,tier2,tier3}\` / \`metadata\` fields. Until a manual rebuild restores the tiered layout, the universe loader silently falls back to the legacy code path.

## Fix

Rewrite \`V3FunnelScreener.run()\` to **merge** today's picks into the existing file:
- Load existing watchlist (graceful when missing or corrupt).
- Preserve \`version\` (default \`\"2.0\"\`) and \`expanded_universe\`.
- Keep \`tiers.{tier1,tier2,tier3}\`; default-construct missing tiers.
- Push picks into \`tiers.tier1.symbols\`, capped at \`max_size\` (default 20).
- Update \`metadata.{last_screened_at, last_screener, picks_count, failed_count}\`.
- Retain legacy top-level \`picks\` / \`details\` / \`failed_symbols\` so old callers (dashboards, main_loop fallback) keep working.

## Tests

\`tests/test_screener_watchlist_merge.py\` — 5 new tests:
- \`test_run_keeps_version_tiers_metadata_when_file_exists\`
- \`test_run_builds_schema_when_file_missing\`
- \`test_run_caps_tier1_at_max_size\`
- \`test_run_recovers_when_existing_file_corrupted\`
- \`test_metadata_records_screener_run\`

Plus a forced \`importlib.reload(v3_pipeline.features.screener)\` at module top to defeat the \`SimpleNamespace(V3FunnelScreener=object)\` stub that \`tests/test_idle_collect.py\` installs via \`sys.modules.setdefault\`. Without this guard the new tests fail in full-suite collection order.

## Verification

\`\`\`
pytest tests/ --ignore=tests/test_pattern_trainer_components.py --ignore=tests/test_model_registry.py
586 passed
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)