### PR TITLE
feat: P0+P1 §9 研究指南 — GRPO P&L reward & ATR dynamic stop-loss

### DIFF
--- a/self_learn/retrain.py
+++ b/self_learn/retrain.py
@@ -2,7 +2,7 @@
 Stage 3: XGBoost Batch Retrain for Self-Learning Trading System.
 
 Builds training data from predictions + outcomes + signals,
-trains an XGBoost classifier to predict trade profitability,
+trains an XGBoost regressor to predict normalized P&L reward,
 and saves a hot-swappable model.
 """
 
@@ -16,7 +16,7 @@ from typing import Optional
 
 import numpy as np
 import xgboost as xgb
-from sklearn.metrics import accuracy_score, classification_report
+from sklearn.metrics import mean_absolute_error
 
 from self_learn.models import (
     session_scope,
@@ -32,12 +32,12 @@ from self_learn.models import (
 
 # ─── Data Joining ──────────────────────────────────────────────────────────────
 
-def build_training_data(max_samples: int = 500) -> tuple[list[np.ndarray], list[int]]:
+def build_training_data(max_samples: int = 500) -> tuple[list[np.ndarray], list[float]]:
     """Build (X, y) training data from predictions + signals + outcomes.
 
     Returns:
         X: list of feature vectors
-        y: list of labels (1=profitable, 0=loss)
+        y: list of normalized P&L rewards in [-1.0, 1.0] (saturates at ±5% pnl_pct)
     """
     with session_scope() as session:
         # Get all closed signals with their outcomes
@@ -52,7 +52,7 @@ def build_training_data(max_samples: int = 500) -> tuple[list[np.ndarray], list[
         )
 
     X_list: list[np.ndarray] = []
-    y_list: list[int] = []
+    y_list: list[float] = []
 
     for signal, outcome, prediction in rows:
         # Try to build rich features from stored indicators dict
@@ -72,8 +72,9 @@ def build_training_data(max_samples: int = 500) -> tuple[list[np.ndarray], list[
                 0.5,                                          # hour=midday
             ], dtype=np.float32)
 
-        # Label: 1 if profitable, 0 if loss
-        label = 1 if (outcome.pnl or 0) > 0 else 0
+        # Reward: normalize pnl_pct to [-1, 1]; saturates at ±5% (research 9.2)
+        raw_pnl_pct = outcome.pnl_pct or 0.0
+        label = max(-1.0, min(1.0, raw_pnl_pct / 5.0))
 
         X_list.append(vec)
         y_list.append(label)
@@ -154,45 +155,37 @@ def _build_feature_vector(prediction: Prediction, signal: Signal, outcome: Outco
 
 # ─── Training ─────────────────────────────────────────────────────────────────
 
-def train_xgboost_model(X: list[np.ndarray], y: list[int]) -> tuple[xgb.XGBClassifier, dict]:
-    """Train XGBoost classifier on feature vectors.
+def train_xgboost_model(X: list[np.ndarray], y: list[float]) -> tuple[xgb.XGBRegressor, dict]:
+    """Train XGBoost regressor on feature vectors to predict normalized P&L reward.
 
     Returns:
-        model: trained XGBClassifier
-        metrics: dict with accuracy, win_rate, sample_count
+        model: trained XGBRegressor
+        metrics: dict with mae, accuracy (proxy: 1-mae), positive_rate, sample_count
     """
     if len(X) < 10:
         raise ValueError(f"Not enough training samples: {len(X)}")
 
     X_arr = np.array(X)
-    y_arr = np.array(y)
+    y_arr = np.array(y, dtype=np.float32)
 
-    # Stratified train/test split (last 20% as holdout)
+    # Chronological train/test split (last 20% as holdout)
     split = int(len(X_arr) * 0.8)
     X_train, X_test = X_arr[:split], X_arr[split:]
     y_train, y_test = y_arr[:split], y_arr[split:]
 
-    # 2026-04-12 Fix: Early stopping + regularization to prevent overfitting
-    # 2026-04-14 Fix: Add scale_pos_weight to handle 80/20 class imbalance.
-    #   minority (profitable, label=1) gets higher weight so the model pays attention.
-    n_neg = sum(1 for v in y if v == 0)
-    n_pos = sum(1 for v in y if v == 1)
-    scale_pos_weight = max(n_neg / max(n_pos, 1), 1.0)  # avoid div-by-zero
-
-    model = xgb.XGBClassifier(
-        n_estimators=150,           # Reduced from 500 — early stopping will find optimal <= 150
+    model = xgb.XGBRegressor(
+        n_estimators=150,
         max_depth=3,
-        learning_rate=0.03,        # Reduced from 0.05 — slower convergence, better generalization
+        learning_rate=0.03,
         subsample=0.8,
         colsample_bytree=0.8,
-        reg_alpha=0.5,             # Increased from 0.1 — stronger L1 to prune noise features
-        reg_lambda=2.0,            # Increased from 1.0 — stronger L2 to prevent overfitting
-        min_child_weight=5,        # Increased from 3 — require more samples per leaf
-        scale_pos_weight=scale_pos_weight,  # weight minority class (profitable trades)
-        eval_metric="logloss",     # Primary metric for early stopping
+        reg_alpha=0.5,
+        reg_lambda=2.0,
+        min_child_weight=5,
+        eval_metric="mae",
         random_state=42,
         n_jobs=-1,
-        early_stopping_rounds=15,  # Stop if no improvement for 15 consecutive rounds
+        early_stopping_rounds=15,
     )
 
     model.fit(
@@ -201,20 +194,19 @@ def train_xgboost_model(X: list[np.ndarray], y: list[int]) -> tuple[xgb.XGBClass
         verbose=False,
     )
 
-    # Evaluate on HOLD-OUT test set only (not training data)
     y_pred = model.predict(X_test)
-    accuracy = accuracy_score(y_test, y_pred)
+    mae = mean_absolute_error(y_test, y_pred)
 
-    # True win rate from test set (proportion of positive class in test)
-    win_rate = float(sum(y_test)) / max(len(y_test), 1)
+    # positive_rate: fraction of trades with reward > 0 (proxy for win rate)
+    positive_rate = float(sum(1 for v in y if v > 0)) / max(len(y), 1)
 
-    # Best iteration from early stopping
-    best_iter = getattr(model, 'best_iteration', None)
-    actual_iters = getattr(model, 'best_iteration', None) or model.n_estimators
+    best_iter = getattr(model, "best_iteration", None)
+    actual_iters = best_iter or model.n_estimators
 
     metrics = {
-        "accuracy": round(float(accuracy), 4),
-        "win_rate": round(float(win_rate), 4),
+        "mae": round(float(mae), 6),
+        "accuracy": round(max(0.0, 1.0 - float(mae)), 4),  # proxy for compatibility
+        "positive_rate": round(positive_rate, 4),
         "train_size": len(X_train),
         "test_size": len(X_test),
         "total_samples": len(X_arr),
@@ -228,7 +220,7 @@ def train_xgboost_model(X: list[np.ndarray], y: list[int]) -> tuple[xgb.XGBClass
 # ─── Model Persistence ──────────────────────────────────────────────────────────
 
 def save_trained_model(
-    model: xgb.XGBClassifier,
+    model: xgb.XGBRegressor,
     metrics: dict,
     model_dir: Path,
 ) -> tuple[str, Path]:
@@ -273,7 +265,7 @@ def get_latest_model_path() -> Optional[Path]:
     return None
 
 
-def load_latest_model() -> Optional[xgb.XGBClassifier]:
+def load_latest_model() -> Optional[xgb.XGBRegressor]:
     """Hot-swap load the most recent trained model."""
     path = get_latest_model_path()
     if path is None:
@@ -286,18 +278,18 @@ def load_latest_model() -> Optional[xgb.XGBClassifier]:
         return None
 
 
-def predict_profitable(model: xgb.XGBClassifier, features: np.ndarray) -> float:
-    """Use trained model to score profitability probability.
+def predict_profitable(model: xgb.XGBRegressor, features: np.ndarray) -> float:
+    """Use trained model to score expected P&L reward as a confidence signal.
 
     Args:
-        model: trained XGBClassifier
+        model: trained XGBRegressor
         features: feature vector (same shape as training)
 
     Returns:
-        probability of being profitable (0.0 - 1.0)
+        confidence in [0.0, 1.0] — mapped from normalized P&L reward [-1, 1]
     """
-    proba = model.predict_proba(features.reshape(1, -1))
-    return float(proba[0][1])
+    pred = model.predict(features.reshape(1, -1))
+    return float((pred[0] + 1.0) / 2.0)
 
 
 # ─── Main Retrain Pipeline ─────────────────────────────────────────────────────
@@ -328,8 +320,9 @@ def retrain_pipeline() -> dict:
             "metrics": metrics,
             "sample_breakdown": {
                 "total": len(y),
-                "profitable": sum(y),
-                "loss": len(y) - sum(y),
+                "positive": sum(1 for v in y if v > 0),
+                "negative": sum(1 for v in y if v <= 0),
+                "mean_reward": round(float(np.mean(y)), 4) if y else 0.0,
             },
         }
         log_file = model_dir / "training_log.jsonl"

--- a/tests/test_quant_v2_kline_cache.py
+++ b/tests/test_quant_v2_kline_cache.py
@@ -18,7 +18,13 @@ class _FakeXGBClassifier:
         pass
 
 
+class _FakeXGBRegressor:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
 fake_xgb.XGBClassifier = _FakeXGBClassifier
+fake_xgb.XGBRegressor = _FakeXGBRegressor
 sys.modules.setdefault("xgboost", fake_xgb)
 
 fake_sklearn = types.ModuleType("sklearn")
@@ -39,9 +45,13 @@ def _fake_split(X, y, test_size=0.2, shuffle=False):
 def _fake_accuracy_score(y_true, y_pred):
     return 0.5
 
+def _fake_mean_absolute_error(y_true, y_pred):
+    return 0.1
+
 fake_pre.StandardScaler = _FakeStandardScaler
 fake_model_selection.train_test_split = _fake_split
 fake_metrics.accuracy_score = _fake_accuracy_score
+fake_metrics.mean_absolute_error = _fake_mean_absolute_error
 
 sys.modules.setdefault("sklearn", fake_sklearn)
 sys.modules.setdefault("sklearn.preprocessing", fake_pre)

--- a/v3_pipeline/core/main_loop.py
+++ b/v3_pipeline/core/main_loop.py
@@ -1732,17 +1732,32 @@ class LiveTradingLoop:
                 entry_price = current_price
                 self.entry_price_by_symbol[symbol] = entry_price
 
-            stop_loss_pct = max(0.0, float(getattr(self.config, "stop_loss_pct", 0.02)))
-            if stop_loss_pct > 0:
-                stop_loss_price = entry_price * (1 - stop_loss_pct)
-                if current_price <= stop_loss_price:
-                    self._execute(symbol, "SELL", qty, current_price, f"stop_loss_{stop_loss_pct:.4f}")
-                    return
+            # ATR-based dynamic stop-loss/take-profit (Section 9.4)
+            atr = None
+            if latest_frame is not None and not latest_frame.empty and "ATR_14" in latest_frame.columns:
+                atr_val = float(latest_frame.iloc[-1].get("ATR_14", 0.0) or 0.0)
+                if atr_val > 0:
+                    atr = atr_val
 
-            quick_tp_pct = max(0.0, float(getattr(self.config, "quick_take_profit_pct", 0.01)))
-            take_profit_price = entry_price * (1 + quick_tp_pct)
+            if atr is not None:
+                stop_loss_price = entry_price - max(atr * 1.5, entry_price * 0.015)
+                take_profit_price = entry_price + max(atr * 2.5, entry_price * 0.03)
+                sl_label = f"atr_stop_loss_atr={atr:.4f}"
+                tp_label = f"atr_take_profit_atr={atr:.4f}"
+            else:
+                stop_loss_pct = max(0.0, float(getattr(self.config, "stop_loss_pct", 0.02)))
+                quick_tp_pct = max(0.0, float(getattr(self.config, "quick_take_profit_pct", 0.01)))
+                stop_loss_price = entry_price * (1 - stop_loss_pct) if stop_loss_pct > 0 else 0.0
+                take_profit_price = entry_price * (1 + quick_tp_pct)
+                sl_label = f"stop_loss_{stop_loss_pct:.4f}"
+                tp_label = f"quick_take_profit_{quick_tp_pct:.4f}"
+
+            if stop_loss_price > 0 and current_price <= stop_loss_price:
+                self._execute(symbol, "SELL", qty, current_price, sl_label)
+                return
+
             if current_price >= take_profit_price:
-                self._execute(symbol, "SELL", qty, current_price, f"quick_take_profit_{quick_tp_pct:.4f}")
+                self._execute(symbol, "SELL", qty, current_price, tp_label)
                 return
 
             max_hold_bars = max(1, int(getattr(self.config, "max_hold_bars", 5)))


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

實作 `CLAUDE_CODE_REWRITE_GUIDE.md` 第 9 節研究指導方針的 P0 + P1 優先項目。

### P0：GRPO Reward → 真實 P&L（`self_learn/retrain.py`）

**問題（§9.2）：** 方向準確率 80% 但勝率僅 37%，根本原因是 reward signal 使用二元方向分類而非真實盈虧。

**變更：**
- `build_training_data()`：label 從 `1 if pnl > 0 else 0` 改為 `clamp(pnl_pct / 5.0, -1, 1)`
- `train_xgboost_model()`：`XGBClassifier` → `XGBRegressor`，`eval_metric` 從 `logloss` 改為 `mae`
- `predict_profitable()`：`predict_proba()[0][1]` → `(predict()[0] + 1) / 2`，映射 `[-1,1]` → `[0,1]`
- metrics dict 改為回報 `mae`、`positive_rate`，保留 `accuracy = 1 - mae` 作向後相容

### P1：ATR-based 動態止蝕（`v3_pipeline/core/main_loop.py`）

**問題（§9.4）：** 固定 2% 止蝕在高波動期過早觸發，錯殺正確交易。

**變更（lines 1735-1760）：**
- 優先從 `latest_frame["ATR_14"]` 取最新 ATR 值
- 止損：`entry - max(ATR×1.5, entry×1.5%)`
- 止盈：`entry + max(ATR×2.5, entry×3%)`
- ATR 不可用時 fallback 至原有百分比邏輯

### 測試

```
574 passed, 1 skipped  ← 與 pre-change baseline 完全相同
```
19 個 `test_yf_provider.py` 失敗為 pre-existing（缺少 `yfinance` 套件）。

## Test plan

- [ ] 確認 `python3 -m pytest tests/ -q --ignore=tests/test_pattern_trainer_components.py --ignore=tests/test_execution_engine_emergency.py --ignore=tests/test_model_registry.py` 顯示 574 passed
- [ ] 確認 `self_learn/retrain.py` 中 `predict_profitable()` 不再呼叫 `predict_proba`
- [ ] 確認 `v3_pipeline/core/main_loop.py` 中止蝕邏輯在有 ATR_14 時使用動態公式，無 ATR_14 時 fallback 至百分比
- [ ] （上線後）觀察 self-learn DB 的 `outcomes.pnl_pct` 作為 reward 是否使模型更新朝正確方向

https://claude.ai/code/session_01U6HovwPAr5TBhmWbvDWET4
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6HovwPAr5TBhmWbvDWET4)_