### PR TITLE
feat: P3 §9.5 MDS pre-filter — Fréchet variation scoring in idle scheduler

### DIFF
--- a/idle_task_scheduler.py
+++ b/idle_task_scheduler.py
@@ -216,6 +216,53 @@ async def _run_historical_backfill(
     return processed
 
 
+def _run_mds_filter(
+    symbols: list[str],
+    loop: "LiveTradingLoop",
+    logger: logging.Logger,
+) -> list[str]:
+    """Compute MDS scores and return filtered symbol list (§9.5).
+
+    Only runs when pool > 50 symbols. Keeps the top 20% most consistent
+    intraday patterns (lowest Fréchet variation score), floored at 10 symbols.
+    Returns original list unchanged when pool is small or data is missing.
+    """
+    if len(symbols) <= 50:
+        return symbols
+
+    try:
+        from v3_pipeline.data.mds_filter import score_symbols, filter_universe, save_scores
+        buffers = {s: loop.market_buffers[s] for s in symbols if s in loop.market_buffers}
+        if not buffers:
+            return symbols
+
+        scores = score_symbols(buffers)
+        filtered = filter_universe(scores)
+
+        # Preserve symbols with no buffer data (no kline yet) in full run
+        no_data = [s for s in symbols if s not in buffers]
+        result = filtered + no_data
+
+        save_scores(scores)
+        _emit(
+            logger,
+            "mds_filter",
+            input_symbols=len(symbols),
+            scored=len(scores),
+            filtered=len(filtered),
+            no_data=len(no_data),
+            output_symbols=len(result),
+        )
+        logger.info(
+            "[mds_filter] %d → %d symbols (scored=%d, no_data=%d)",
+            len(symbols), len(result), len(filtered), len(no_data),
+        )
+        return result
+    except Exception as exc:
+        logger.warning("[mds_filter] failed, using full symbol list: %s", exc)
+        return symbols
+
+
 async def _run_indicator_warmup(
     symbols: list[str],
     loop: "LiveTradingLoop",
@@ -432,7 +479,15 @@ class IdleTaskScheduler:
             self.logger.info("[backfill] done: %d symbols in %.1fs", n, time.time() - t0)
             _emit_fd_health(self.logger, "post_backfill")
 
-            # Task 2: Indicator warmup
+            # Task 1.5: MDS pre-filter — only when pool > 50 symbols (§9.5)
+            if len(symbols) > 50:
+                t0 = time.time()
+                symbols = await asyncio.to_thread(
+                    _run_mds_filter, symbols, self.loop, self.logger
+                )
+                self.logger.info("[mds_filter] done in %.1fs → %d symbols", time.time() - t0, len(symbols))
+
+            # Task 2: Indicator warmup (on MDS-filtered symbol set)
             if self._stop_event.is_set():
                 return
             mins_left = self._minutes_until_next_open()

--- a/v3_pipeline/data/mds_filter.py
+++ b/v3_pipeline/data/mds_filter.py
@@ -1,0 +1,118 @@
+"""
+MDS (Metric Dependence Screening) pre-filter for symbol universe.
+
+§9.5 research guide: pre-screen candidates by Fréchet variation score
+computed from daily returns (scalar) + intraday risk curve (functional proxy).
+Lower score = more consistent intraday pattern = higher quality candidate.
+
+Trigger conditions (§9.5):
+  - Candidate pool > 50 symbols
+  - Regime = Risk-Off
+  - HK small-cap / low-liquidity market
+
+Usage:
+  scores = score_symbols(market_buffers)
+  filtered = filter_universe(scores, top_pct=0.20, min_symbols=10)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:
+    pass
+
+_MDS_SCORES_PATH = Path(__file__).parent.parent.parent / "data" / "mds_scores.json"
+_MIN_BARS = 20
+_TOP_PCT_DEFAULT = 0.20
+_MIN_SYMBOLS_DEFAULT = 10
+
+
+def _frechet_variation_score(df: pd.DataFrame) -> float:
+    """Compute simplified Fréchet variation score for one symbol.
+
+    Uses coefficient of variation of the intraday range percentage as a
+    functional-data proxy for the intraday risk curve (§9.5).
+
+    Lower score = more consistent intraday pattern = better candidate.
+    Returns float('inf') when data is insufficient.
+    """
+    if df is None or len(df) < _MIN_BARS:
+        return float("inf")
+
+    try:
+        high = df["High"].values.astype(float)
+        low = df["Low"].values.astype(float)
+        close = df["Close"].values.astype(float)
+
+        # Intraday range as fraction of close — proxy for daily risk curve
+        prev_close = np.roll(close, 1)
+        prev_close[0] = close[0]
+        range_pct = (high - low) / np.where(prev_close > 0, prev_close, 1.0)
+        mean_range = float(np.nanmean(range_pct))
+        if mean_range <= 0:
+            return float("inf")
+        cv_range = float(np.nanstd(range_pct)) / mean_range  # coefficient of variation
+
+        # Daily return volatility — penalise highly erratic symbols
+        returns = np.diff(close) / np.where(close[:-1] > 0, close[:-1], 1.0)
+        vol_return = float(np.nanstd(returns))
+
+        # Combined score: lower = more predictable
+        return cv_range * (1.0 + vol_return * 10.0)
+    except Exception:
+        return float("inf")
+
+
+def score_symbols(market_buffers: dict[str, pd.DataFrame]) -> dict[str, float]:
+    """Return a {symbol: mds_score} dict for all symbols with enough data.
+
+    Lower MDS score = more consistent intraday pattern.
+    """
+    scores: dict[str, float] = {}
+    for sym, df in market_buffers.items():
+        scores[sym] = _frechet_variation_score(df)
+    return scores
+
+
+def filter_universe(
+    scores: dict[str, float],
+    top_pct: float = _TOP_PCT_DEFAULT,
+    min_symbols: int = _MIN_SYMBOLS_DEFAULT,
+) -> list[str]:
+    """Return symbols with the lowest (best) MDS scores.
+
+    Keeps top `top_pct` fraction (default 20%), floored at `min_symbols`.
+    Symbols with infinite score (insufficient data) are always excluded from
+    the filtered set but not from the fallback — caller must handle that.
+    """
+    finite = {s: v for s, v in scores.items() if v != float("inf")}
+    if not finite:
+        return list(scores.keys())
+
+    sorted_syms = sorted(finite, key=lambda s: finite[s])
+    n_keep = max(min_symbols, int(len(sorted_syms) * top_pct))
+    n_keep = min(n_keep, len(sorted_syms))
+    return sorted_syms[:n_keep]
+
+
+def save_scores(scores: dict[str, float], path: Path = _MDS_SCORES_PATH) -> None:
+    """Persist MDS scores to data/mds_scores.json for inspection."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    serialisable = {s: (v if v != float("inf") else None) for s, v in scores.items()}
+    sorted_entry = dict(sorted(serialisable.items(), key=lambda x: (x[1] is None, x[1] or 0)))
+    path.write_text(json.dumps(sorted_entry, indent=2))
+
+
+def load_scores(path: Path = _MDS_SCORES_PATH) -> dict[str, float]:
+    """Load previously saved MDS scores; returns {} if file absent."""
+    try:
+        raw = json.loads(path.read_text())
+        return {s: float("inf") if v is None else float(v) for s, v in raw.items()}
+    except Exception:
+        return {}


### PR DESCRIPTION
Cherry-pick of original PR #95 from `claude/implement-point-9-solution-C5Iag`. Same content, rebased cleanly onto current main to resolve merge conflicts.

## Summary

實作 §9.5 MDS（Metric Dependence Screening）前置過濾層，在 idle 排程器中加入 Fréchet 變分評分。

### 新增：
-  — 對每個 symbol 計算 Fréchet variation 分數
-  — 保留最低分的前 20%
-  /  — 持久化至 

### 修改：
- Task 1.5：MDS pre-filter，觸發條件 
- 失敗時自動 fallback 至完整 symbol 列表

## Test plan
- [x] pytest: 593 passed, 1 skipped
- [x] MDS filter logic functional test passed

*Originally authored by Claude Code* 